### PR TITLE
fdtdump.c: provide colored output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+before_install:
+	sudo apt-get updated
+	sudo apt-get install libncurses5-dev
+
 language: c
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CONFIG_LOCALVERSION =
 CPPFLAGS = -I libfdt -I .
 WARNINGS = -Wall -Wpointer-arith -Wcast-qual -Wnested-externs \
 	-Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Wshadow
-CFLAGS = -g -Os -fPIC -Werror $(WARNINGS)
+CFLAGS = -g -Os -fPIC -Werror $(WARNINGS) -lncurses
 
 BISON = bison
 LEX = flex

--- a/util.c
+++ b/util.c
@@ -36,6 +36,8 @@
 #include "util.h"
 #include "version_gen.h"
 
+int colored = 0;
+
 char *xstrdup(const char *s)
 {
 	int len = strlen(s) + 1;
@@ -389,7 +391,7 @@ void utilfdt_print_data(const char *data, int len)
 
 		s = data;
 		do {
-			printf("\"%s\"", s);
+			printf("\"%s%s%s\"", COLSTRG, s, COLNONE);
 			s += strlen(s) + 1;
 			if (s < data + len)
 				printf(", ");
@@ -398,17 +400,17 @@ void utilfdt_print_data(const char *data, int len)
 	} else if ((len % 4) == 0) {
 		const uint32_t *cell = (const uint32_t *)data;
 
-		printf(" = <");
+		printf(" = <%s", COLNUMB);
 		for (i = 0, len /= 4; i < len; i++)
 			printf("0x%08x%s", fdt32_to_cpu(cell[i]),
 			       i < (len - 1) ? " " : "");
-		printf(">");
+		printf("%s>", COLNONE);
 	} else {
 		const unsigned char *p = (const unsigned char *)data;
-		printf(" = [");
+		printf(" = [%s", COLBYTE);
 		for (i = 0; i < len; i++)
 			printf("%02x%s", *p++, i < len - 1 ? " " : "");
-		printf("]");
+		printf("%s]", COLNONE);
 	}
 }
 

--- a/util.h
+++ b/util.h
@@ -25,6 +25,14 @@
  *                                                                   USA
  */
 
+extern int colored;
+#define COLNODE (colored ? "\x1b[35m" : "") /* magenta */
+#define COLPROP (colored ? "\x1b[32m" : "") /* green */
+#define COLSTRG (colored ? "\x1b[33m" : "") /* yellow */
+#define COLNUMB (colored ? "\x1b[34m" : "") /* blue */
+#define COLBYTE (colored ? "\x1b[36m" : "") /* cyan */
+#define COLNONE (colored ? "\x1b[0m" : "")  /* default */
+
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
 static inline void __attribute__((noreturn)) die(const char *str, ...)


### PR DESCRIPTION
A new command line option is added
  -c, --color <arg> Colorize, argument can be auto, never or always
which defaults to auto.

For colored output in pipes use 'always', e.g.
  fdtdump -c always file.dtb | less -R

If you don't like colors use
alias fdtdump="fdtdump -c none"

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>