### PR TITLE
Fix boundary check in fdt_strerror

### DIFF
--- a/libfdt/fdt_strerror.c
+++ b/libfdt/fdt_strerror.c
@@ -91,7 +91,7 @@ const char *fdt_strerror(int errval)
 		return "<valid offset/length>";
 	else if (errval == 0)
 		return "<no error>";
-	else if (errval > -FDT_ERRTABSIZE) {
+	else if (-errval < FDT_ERRTABSIZE) {
 		const char *s = fdt_errtable[-errval].str;
 
 		if (s)


### PR DESCRIPTION
minus operator applied to unsigned type, result still unsigned -> the check always results in false and the function returns `"<unknown error>"`.
Also even if the check would pass it would do an out of bounds reading of the fdt_errtable table on fdt_strerror(FDT_ERRTABSIZE) function call.