### PR TITLE
pylibftd: fdt_get_mem_rsv returns 2 uint64_t values

### DIFF
--- a/pylibfdt/libfdt.i
+++ b/pylibfdt/libfdt.i
@@ -1068,7 +1068,7 @@ typedef uint32_t fdt32_t;
 }
 
 %typemap(argout) uint64_t * {
-        PyObject *val = PyLong_FromUnsignedLong(*arg$argnum);
+        PyObject *val = PyLong_FromUnsignedLongLong(*arg$argnum);
         if (!result) {
            if (PyTuple_GET_SIZE(resultobj) == 0)
               resultobj = val;


### PR DESCRIPTION
Fix typemap for fdt_get_mem_rsv so it returns 64-bit values.

Fixes issue #15

Signed-off-by: Dan Horák <dan@danny.cz>