### PR TITLE
use ptrdiff_t modifier for printing pointer differences

### DIFF
--- a/fdtdump.c
+++ b/fdtdump.c
@@ -100,7 +100,7 @@ static void dump_blob(void *blob, bool debug)
 	p = p_struct;
 	while ((tag = fdt32_to_cpu(GET_CELL(p))) != FDT_END) {
 
-		dumpf("%04zx: tag: 0x%08"PRIx32" (%s)\n",
+		dumpf("%04tx: tag: 0x%08"PRIx32" (%s)\n",
 		        (uintptr_t)p - blob_off - 4, tag, tagname(tag));
 
 		if (tag == FDT_BEGIN_NODE) {
@@ -140,8 +140,8 @@ static void dump_blob(void *blob, bool debug)
 
 		p = PALIGN(p + sz, 4);
 
-		dumpf("%04zx: string: %s\n", (uintptr_t)s - blob_off, s);
-		dumpf("%04zx: value\n", (uintptr_t)t - blob_off);
+		dumpf("%04tx: string: %s\n", (uintptr_t)s - blob_off, s);
+		dumpf("%04tx: value\n", (uintptr_t)t - blob_off);
 		printf("%*s%s", depth * shift, "", s);
 		utilfdt_print_data(t, sz);
 		printf(";\n");
@@ -229,14 +229,14 @@ int main(int argc, char *argv[])
 				if (valid_header(p, this_len))
 					break;
 				if (debug)
-					printf("%s: skipping fdt magic at offset %#zx\n",
+					printf("%s: skipping fdt magic at offset %#tx\n",
 						file, p - buf);
 			}
 			++p;
 		}
 		if (!p || endp - p < sizeof(struct fdt_header))
 			die("%s: could not locate fdt magic\n", file);
-		printf("%s: found fdt at offset %#zx\n", file, p - buf);
+		printf("%s: found fdt at offset %#tx\n", file, p - buf);
 		buf = p;
 	} else if (!valid_header(buf, len))
 		die("%s: header is not valid\n", file);


### PR DESCRIPTION
Use ptrdiff_t modifier (%tx) for printing a difference between 2 pointers. Currently
%zx (size_t) is used, but it fails on platforms where size_t and ptrdiff_t are
defined differently (like s390).

Comes from
https://src.fedoraproject.org/rpms/dtc/c/f3da2d1b00d01d83fef7001d5767baa3d5a6df87?branch=master
originally.