### PR TITLE
libfdt: return correct value if #size-cells property is not present

### DIFF
--- a/libfdt/fdt_addresses.c
+++ b/libfdt/fdt_addresses.c
@@ -64,7 +64,7 @@ static int fdt_cells(const void *fdt, int nodeoffset, const char *name)
 
 	c = fdt_getprop(fdt, nodeoffset, name, &len);
 	if (!c)
-		return 2;
+		return len;
 
 	if (len != sizeof(*c))
 		return -FDT_ERR_BADNCELLS;
@@ -78,10 +78,20 @@ static int fdt_cells(const void *fdt, int nodeoffset, const char *name)
 
 int fdt_address_cells(const void *fdt, int nodeoffset)
 {
-	return fdt_cells(fdt, nodeoffset, "#address-cells");
+	int val;
+
+	val = fdt_cells(fdt, nodeoffset, "#address-cells");
+	if (val == -FDT_ERR_NOTFOUND)
+		return 2;
+	return val;
 }
 
 int fdt_size_cells(const void *fdt, int nodeoffset)
 {
-	return fdt_cells(fdt, nodeoffset, "#size-cells");
+	int val;
+
+	val = fdt_cells(fdt, nodeoffset, "#size-cells");
+	if (val == -FDT_ERR_NOTFOUND)
+		return 1;
+	return val;
 }

--- a/libfdt/libfdt.h
+++ b/libfdt/libfdt.h
@@ -1145,7 +1145,7 @@ int fdt_address_cells(const void *fdt, int nodeoffset);
  *
  * returns:
  *	0 <= n < FDT_MAX_NCELLS, on success
- *      2, if the node has no #size-cells property
+ *      1, if the node has no #size-cells property
  *      -FDT_ERR_BADNCELLS, if the node has a badly formatted or invalid
  *		#size-cells property
  *	-FDT_ERR_BADMAGIC,

--- a/tests/addr_size_cells.c
+++ b/tests/addr_size_cells.c
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
 	fdt = load_blob(argv[1]);
 
 	check_node(fdt, "/", 2, 2);
-	check_node(fdt, "/identity-bus@0", 2, 2);
+	check_node(fdt, "/identity-bus@0", 2, 1);
 	check_node(fdt, "/simple-bus@1000000", 2, 1);
 	check_node(fdt, "/c0", -FDT_ERR_BADNCELLS, -FDT_ERR_BADNCELLS);
 	check_node(fdt, "/c1", -FDT_ERR_BADNCELLS, -FDT_ERR_BADNCELLS);

--- a/tests/addr_size_cells2.c
+++ b/tests/addr_size_cells2.c
@@ -57,6 +57,6 @@ int main(int argc, char *argv[])
 	test_init(argc, argv);
 	fdt = load_blob(argv[1]);
 
-	check_node(fdt, "/", 2, 2);
+	check_node(fdt, "/", 2, 1);
 	PASS();
 }


### PR DESCRIPTION
According to the device tree specification, the default value for
#size-cells is 1, but fdt_size_cells() was returning 2 if this property
was not present.

This patch also makes fdt_address_cells() and fdt_size_cells() conform
to the behaviour documented in libfdt.h. The defaults are only returned
if fdt_getprop() returns -FDT_ERR_NOTFOUND, otherwise the actual error
is returned.