### PR TITLE
libfdt: Make fdt_cells function accessible

### DIFF
--- a/libfdt/fdt_addresses.c
+++ b/libfdt/fdt_addresses.c
@@ -11,7 +11,7 @@
 
 #include "libfdt_internal.h"
 
-static int fdt_cells(const void *fdt, int nodeoffset, const char *name)
+int fdt_cells(const void *fdt, int nodeoffset, const char *name)
 {
 	const fdt32_t *c;
 	uint32_t val;

--- a/libfdt/libfdt.h
+++ b/libfdt/libfdt.h
@@ -1193,6 +1193,27 @@ int fdt_address_cells(const void *fdt, int nodeoffset);
  */
 int fdt_size_cells(const void *fdt, int nodeoffset);
 
+/**
+ * fdt_cells - retrive size of cells specified by parameter name.
+ * @fdt: pointer to the device tree blob
+ * @nodeoffset: offset of the node to find the address range size for
+ * @name: name of the property which size we want to read
+ *
+ * When the node has a valid property define in name, returns its value.
+ *
+ * returns:
+ *	0 <= n < FDT_MAX_NCELLS, on success
+ *      -FDT_ERR_NOTFOUND, if the node has no property specified in paramter
+		name
+ *      -FDT_ERR_BADNCELLS, if the node has a badly formatted or invalid
+ *		#size-cells property
+ *	-FDT_ERR_BADMAGIC,
+ *	-FDT_ERR_BADVERSION,
+ *	-FDT_ERR_BADSTATE,
+ *	-FDT_ERR_BADSTRUCTURE,
+ *	-FDT_ERR_TRUNCATED, standard meanings
+ */
+int fdt_cells(const void *fdt, int nodeoffset, const char *name);
 
 /**********************************************************************/
 /* Write-in-place functions                                           */


### PR DESCRIPTION
For reading address-cells and size-cells, the libfdt only provides
functions which do not return in case the node does not provide the
property. For traversing the DT to find the parent node which provides
this property we will need to know that.

Make fdt_cells accessible from outside of libfdt so that we can detect
not present size- and address-cells properties in a node.

Signed-off-by: Matthias Brugger <mbrugger@suse.com>