### PR TITLE
libfdt: Export overlay_apply_node() as fdt_overlay_apply_node()

### DIFF
--- a/libfdt/fdt_overlay.c
+++ b/libfdt/fdt_overlay.c
@@ -879,3 +879,8 @@ err:
 
 	return ret;
 }
+
+int fdt_overlay_apply_node(void *fdt, int target, void *fdto, int node)
+{
+	return overlay_apply_node(fdt, target, fdto, node);
+}

--- a/libfdt/libfdt.h
+++ b/libfdt/libfdt.h
@@ -2063,6 +2063,13 @@ int fdt_del_node(void *fdt, int nodeoffset);
  */
 int fdt_overlay_apply(void *fdt, void *fdto);
 
+/**
+ * fdt_overlay_apply_node - Merges a node into the base device tree
+ *
+ * See overlay_apply_node() for details.
+ */
+int fdt_overlay_apply_node(void *fdt, int target, void *fdto, int node);
+
 /**********************************************************************/
 /* Debugging / informational functions                                */
 /**********************************************************************/


### PR DESCRIPTION
This function is useful to merge a subset of DT into another DT, for
example if some prior-stage firmware passes a DT fragment to U-Boot
and U-Boot needs to merge it into its own DT. Export this function
to permit implementing such functionality.