### PR TITLE
Makefile: Specify cflags for libyaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ ifeq ($(NO_YAML),1)
 	CFLAGS += -DNO_YAML
 else
 	LDLIBS_dtc += $(shell $(PKG_CONFIG) --libs yaml-0.1)
+	CFLAGS += $(shell $(PKG_CONFIG) --cflags yaml-0.1)
 endif
 
 ifeq ($(HOSTOS),darwin)


### PR DESCRIPTION
Some systems don't install third party software includes in a default
path (like FreeBSD), add yaml cflags to fix compilation.

Signed-off-by: Emmanuel Vadot <manu@FreeBSD.org>