### PR TITLE
False effective head detection: fdt_totalsize(p) equal the len of dtb

### DIFF
--- a/fdtdump.c
+++ b/fdtdump.c
@@ -169,7 +169,7 @@ static bool valid_header(char *p, size_t len)
 	    fdt_magic(p) != FDT_MAGIC ||
 	    fdt_version(p) > MAX_VERSION ||
 	    fdt_last_comp_version(p) > MAX_VERSION ||
-	    fdt_totalsize(p) >= len ||
+	    fdt_totalsize(p) > len ||
 	    fdt_off_dt_struct(p) >= len ||
 	    fdt_off_dt_strings(p) >= len)
 		return 0;


### PR DESCRIPTION
file should be legitimate

Signed-off-by: juiceRv <juicemail@163.com>
https://github.com/dgibson/dtc/issues/52#issue-964778171