### PR TITLE
dtc: introduce label relative path references

### DIFF
--- a/dtc-lexer.l
+++ b/dtc-lexer.l
@@ -200,7 +200,7 @@ static void PRINTF(1, 2) lexical_error(const char *fmt, ...);
 			return DT_LABEL_REF;
 		}
 
-<*>"&{/"{PATHCHAR}*\}	{	/* new-style path reference */
+<*>"&{"{PATHCHAR}*\}	{	/* new-style path reference */
 			yytext[yyleng-1] = '\0';
 			DPRINT("Ref: %s\n", yytext+2);
 			yylval.labelref = xstrdup(yytext+2);

--- a/dtc-parser.y
+++ b/dtc-parser.y
@@ -23,6 +23,12 @@ extern void yyerror(char const *s);
 
 extern struct dt_info *parser_output;
 extern bool treesource_error;
+
+static bool is_ref_relative(const char *ref)
+{
+	return ref[0] != '/' && strchr(&ref[1], '/');
+}
+
 %}
 
 %union {
@@ -169,6 +175,8 @@ devicetree:
 			 */
 			if (!($<flags>-1 & DTSF_PLUGIN))
 				ERROR(&@2, "Label or path %s not found", $1);
+			else if (is_ref_relative($1))
+				ERROR(&@2, "Label-relative reference %s not supported in plugin", $1);
 			$$ = add_orphan_node(
 					name_node(build_node(NULL, NULL, NULL),
 						  ""),
@@ -177,6 +185,9 @@ devicetree:
 	| devicetree DT_LABEL dt_ref nodedef
 		{
 			struct node *target = get_node_by_ref($1, $3);
+
+			if (($<flags>-1 & DTSF_PLUGIN) && is_ref_relative($3))
+				ERROR(&@2, "Label-relative reference %s not supported in plugin", $3);
 
 			if (target) {
 				add_label(&target->labels, $2);
@@ -193,6 +204,8 @@ devicetree:
 			 * so $-1 is what we want (plugindecl)
 			 */
 			if ($<flags>-1 & DTSF_PLUGIN) {
+				if (is_ref_relative($2))
+					ERROR(&@2, "Label-relative reference %s not supported in plugin", $2);
 				add_orphan_node($1, $3, $2);
 			} else {
 				struct node *target = get_node_by_ref($1, $2);

--- a/livetree.c
+++ b/livetree.c
@@ -581,12 +581,39 @@ struct node *get_node_by_phandle(struct node *tree, cell_t phandle)
 
 struct node *get_node_by_ref(struct node *tree, const char *ref)
 {
+	struct node *target = tree;
+	const char *label = NULL, *path = NULL;
+
 	if (streq(ref, "/"))
 		return tree;
-	else if (ref[0] == '/')
-		return get_node_by_path(tree, ref);
+
+	if (ref[0] == '/')
+		path = ref;
 	else
-		return get_node_by_label(tree, ref);
+		label = ref;
+
+	if (label) {
+		const char *slash = strchr(label, '/');
+		char *buf = NULL;
+
+		if (slash) {
+			buf = xstrndup(label, slash - label);
+			label = buf;
+			path = slash + 1;
+		}
+
+		target = get_node_by_label(tree, label);
+
+		free(buf);
+
+		if (!target)
+			return NULL;
+	}
+
+	if (path)
+		target = get_node_by_path(target, path);
+
+	return target;
 }
 
 cell_t get_node_phandle(struct node *root, struct node *node)

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -54,6 +54,7 @@ tmp.*
 /property_iterate
 /propname_escapes
 /references
+/relref_merge
 /root_node
 /rw_tree1
 /rw_oom

--- a/tests/Makefile.tests
+++ b/tests/Makefile.tests
@@ -18,7 +18,7 @@ LIB_TESTS_L = get_mem_rsv \
 	open_pack rw_tree1 rw_oom set_name setprop del_property del_node \
 	appendprop1 appendprop2 propname_escapes \
 	string_escapes references path-references phandle_format \
-	boot-cpuid incbin \
+	boot-cpuid incbin relref_merge \
 	extra-terminating-null \
 	dtbs_equal_ordered \
 	dtb_reverse dtbs_equal_unordered \

--- a/tests/path-references.c
+++ b/tests/path-references.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
 	void *fdt;
 	const char *p;
 	int len, multilen;
-	int n1, n2, n3, n4;
+	int n1, n2, n3, n4, n5;
 
 	test_init(argc, argv);
 	fdt = load_blob_arg(argc, argv);
@@ -88,6 +88,12 @@ int main(int argc, char *argv[])
 		FAIL("fdt_path_offset(/foobar/baz): %s", fdt_strerror(n4));
 	check_ref(fdt, n3, "/foobar/baz");
 	check_ref(fdt, n4, "/foo/baz");
+
+	n5 = fdt_path_offset(fdt, "/bar/baz");
+	if (n5 < 0)
+		FAIL("fdt_path_offset(/bar/baz): %s", fdt_strerror(n5));
+
+	check_ref(fdt, n5, "/bar/baz");
 
 	check_rref(fdt);
 

--- a/tests/path-references.dts
+++ b/tests/path-references.dts
@@ -25,4 +25,13 @@
 			lref = &n3;
 		};
 	};
+	n5: bar {
+		baz {
+		};
+	};
+};
+
+n6: &{n5/baz} {
+	ref = &{n6/};
+	lref = &{n5/baz};
 };

--- a/tests/relref_merge.c
+++ b/tests/relref_merge.c
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * libfdt - Flat Device Tree manipulation
+ *	Testcase for label relative child references in dtc
+ * Copyright (C) 2006 David Gibson, IBM Corporation.
+ * Copyright (C) 2020 Ahmad Fatoum, Pengutronix.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include <libfdt.h>
+
+#include "tests.h"
+#include "testdata.h"
+
+static void check_exist(void *fdt, const char *path)
+{
+	int sn = fdt_path_offset(fdt, path);
+	if (sn < 0)
+		FAIL("%s expected but not found: %s", path, fdt_strerror(sn));
+}
+
+static void check_doesnt_exist(void *fdt, const char *path)
+{
+	int sn = fdt_path_offset(fdt, path);
+	if (sn >= 0)
+		FAIL("%s found but not expected %d", path, sn);
+}
+
+int main(int argc, char *argv[])
+{
+	void *fdt;
+
+	test_init(argc, argv);
+	fdt = load_blob_arg(argc, argv);
+
+	check_exist(fdt, "/node/subnode1");
+	check_exist(fdt, "/node/keep-me");
+	check_doesnt_exist(fdt, "/node/remove-me");
+
+	check_doesnt_exist(fdt, "/node2");
+	check_doesnt_exist(fdt, "/node/subnode3");
+
+	check_exist(fdt, "/node/subnode4");
+
+	check_exist(fdt, "/node/subnode1/add-me");
+
+	PASS();
+}

--- a/tests/relref_merge.dts
+++ b/tests/relref_merge.dts
@@ -1,0 +1,40 @@
+/dts-v1/;
+
+/ {
+	node_label: node {
+		keep-me {};
+		remove-me {};
+
+		subnode1 {
+			property-inline1;
+			property-inline2;
+			property-inline3;
+		};
+
+		subnode2 {
+			property-inline1;
+		};
+
+		subnode3 {
+			property-inline1;
+		};
+	};
+
+	node2_label: node2 {
+		property-inline1;
+	};
+};
+/omit-if-no-ref/ &{node_label/subnode1};
+/omit-if-no-ref/ &node2_label;
+/delete-node/ &{node_label/subnode3};
+
+&{node_label/} {
+	/delete-node/ remove-me;
+
+	subnode4 { };
+};
+
+label: &{node_label/subnode1} {
+	selfref = &{node_label/subnode1};
+	add-me { };
+};

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -669,6 +669,9 @@ dtc_tests () {
     tree1_tests dtc_tree1_merge_path.test.dtb test_tree1.dtb
     run_wrap_error_test $DTC -I dts -O dtb -o /dev/null "$SRCDIR/test_label_ref.dts"
 
+    run_dtc_test -I dts -O dtb -o dtc_relref_merge.test.dtb "$SRCDIR/relref_merge.dts"
+    run_test relref_merge dtc_relref_merge.test.dtb
+
     # Check prop/node delete functionality
     run_dtc_test -I dts -O dtb -o dtc_tree1_delete.test.dtb "$SRCDIR/test_tree1_delete.dts"
     tree1_tests dtc_tree1_delete.test.dtb

--- a/util.c
+++ b/util.c
@@ -33,6 +33,17 @@ char *xstrdup(const char *s)
 	return d;
 }
 
+char *xstrndup(const char *s, size_t n)
+{
+	size_t len = strnlen(s, n) + 1;
+	char *d = xmalloc(len);
+
+	memcpy(d, s, len - 1);
+	d[len - 1] = '\0';
+
+	return d;
+}
+
 int xavsprintf_append(char **strp, const char *fmt, va_list ap)
 {
 	int n, size = 0;	/* start with 128 bytes */

--- a/util.h
+++ b/util.h
@@ -61,6 +61,7 @@ static inline void *xrealloc(void *p, size_t len)
 }
 
 extern char *xstrdup(const char *s);
+extern char *xstrndup(const char *s, size_t len);
 
 extern int PRINTF(2, 3) xasprintf(char **strp, const char *fmt, ...);
 extern int PRINTF(2, 3) xasprintf_append(char **strp, const char *fmt, ...);


### PR DESCRIPTION
Reference via label allows extending nodes with compile-time checking of
whether the node being extended exists. This is useful to catch
renamed/removed nodes after an update of the device trees to be extended.

In absence of labels in the original device trees, new style path
references can be used:

```
/* upstream device tree */
/ {
	leds: some-non-standard-led-controller-name {
		led-0 {
			default-state = "off";
		};
	};
};

/* downstream device tree */
&{/some-non-standard-led-controller-name/led-0} {
	default-state = "on";
};
```

This is a common theme within the barebox bootloader[0], which extends the
upstream (Linux) device trees in that manner. The downside is that,
especially for deep nodes, these references can get quite long and tend to
break often due to upstream rework (e.g. rename to adhere to bindings).

Often there is a label a level or two higher that could be used. This
patch allows combining both a label and a new style path reference to
get a compile-time-checked reference, which allows rewriting the
previous downstream device tree snippet to:

```
&leds/led-0 {
	default-state = "on";
};
```

This won't be broken when `/some-non-standard-led-controller-name` is
renamed or moved while keeping the label. And if `led-0` is renamed, we
will get the expected compile-time error.

Overlay support is skipped for now as they require special support: The
label and relative path parts need to be resolved at overlay apply-time,
not at compile-time.

[0]: https://www.barebox.org/doc/latest/devicetree/index.html
