### PR TITLE
CI: Cirrus: bump used FreeBSD from 12.1 to 13.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,9 @@
 env:
   CIRRUS_CLONE_DEPTH: 1
 
-freebsd_12_task:
+freebsd_13_task:
   freebsd_instance:
-    image: freebsd-12-1-release-amd64
+    image: freebsd-13-0-release-amd64
   install_script:
     pkg install -y bison gmake pkgconf
   build_script:


### PR DESCRIPTION
CI freebsd_12 job currently fails to build PRs, because of:
```
ld-elf.so.1: /usr/local/bin/bison: Undefined symbol "fread_unlocked@FBSD_1.6"
```

According to FreeBSD issue tracker[1], the proper solution is to upgrade to a
supported release, so do that for our CI.

[1]: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=253452