### PR TITLE
tests: setprop_inplace: use xstrdup instead of unchecked strdup

### DIFF
--- a/tests/setprop_inplace.c
+++ b/tests/setprop_inplace.c
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
 			     TEST_STRING_1);
 
 	verbose_printf("Old string value was \"%s\"\n", strp);
-	xstr = strdup(strp);
+	xstr = xstrdup(strp);
 	xlen = strlen(xstr);
 	for (i = 0; i < xlen; i++)
 		xstr[i] = toupper(xstr[i]);


### PR DESCRIPTION
This is the only `strdup` instance we have, all others are `xstrdup`. As
`strdup` is `_POSIX_C_SOURCE >= v200809L`, which we don't require and we
don't check `strdup` error return here, switch to `xstrdup` instead. This
aligns the test with others that call `x`funcs, mainly `xmalloc()`.