### PR TITLE
Fix display of hex char literals in device tree source format

### DIFF
--- a/treesource.c
+++ b/treesource.c
@@ -93,7 +93,7 @@ static void write_propval_string(FILE *f, const char *s, size_t len)
 			if (isprint((unsigned char)c))
 				fprintf(f, "%c", c);
 			else
-				fprintf(f, "\\x%02"PRIx8, c);
+				fprintf(f, "\\x%02"PRIx8, (unsigned char)c);
 		}
 	}
 	fprintf(f, "\"");


### PR DESCRIPTION
The format specifier `PRIx8` for unsigned integers was used with a
signed character parameter, yielding unexpected results with values > 0x7F.

If you run for instance `dtc -I dts -O dts tests/escapes.dts`, you can notice
that the value of the `escape-str-2` property, which is initially `"\xde\xad\xbe\xef"`, is not
printed correctly:

```
/dts-v1/;

/ {
	compatible = "test_string_escapes";
	escape-str = "nastystring: \a\b\t\n\v\f\r\\\"";
	escape-str-2 = "\xffffffde\xffffffad\xffffffbe\xffffffef";
};
```
This happens because the signed character is type-converted to an int, which should not be used with the `%x` format specifier.
I fixed this by casting to an `unsigned char`; another possible way is to add `hh` to the format specifier but I find the former more self-explanatory.

For a bit of context, I found this as I was attempting to "canonize" DTS files by running `dtc -I dts -O dts` until it reached a fix-point (it so happens that resolution of path and label refs leave an extra space -- due to the markers --  in data blobs, so one must run dtc twice on a file to reach a stable result).
