### PR TITLE
Update README in MANIFEST.in and setup.py to README.md

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later OR BSD-2-Clause)
 
 global-exclude *
-include README
+include README.md
 include GPL
 include BSD-2-Clause
 include setup.py

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import sys
 
 srcdir = os.path.dirname(__file__)
 
-with open(os.path.join(srcdir, "README"), "r") as fh:
+with open(os.path.join(srcdir, "README.md"), "r") as fh:
     long_description = fh.read()
 
 def get_top_builddir():


### PR DESCRIPTION
`README` is updated to `README.md` in `MANIFEST.in` and `setup.py` as it was renamed from `README` to `README.md` recently.

`make check` result:
```
********** TEST SUMMARY
*     Total testcases:	2053
*                PASS:	2053
*                FAIL:	0
*   Bad configuration:	0
* Strange test result:	0
**********
```