### PR TITLE
Fix make 4.4 recursion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,3 +389,7 @@ clean: libfdt_clean pylibfdt_clean tests_clean
 	$(BISON) -b $(basename $(basename $@)) -d $<
 
 FORCE:
+
+ifeq ($(MAKE_RESTARTS),10)
+$(error "Make re-executed itself $(MAKE_RESTARTS) times. Infinite recursion?")
+endif

--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ clean: libfdt_clean pylibfdt_clean tests_clean
 	@$(VECHO) LEX $@
 	$(LEX) -o$@ $<
 
-%.tab.c %.tab.h %.output: %.y
+%.tab.c %.tab.h: %.y
 	@$(VECHO) BISON $@
 	$(BISON) -b $(basename $(basename $@)) -d $<
 


### PR DESCRIPTION
Makefile: fix infinite recursion by dropping non-existent `%.output`

Without the change GNU `make-4.4` falls into infinite recursion of trying
to generate %.output files (bison is not passed flags to generate debug
output).

This happens on GNU `make-4.4` only after GNU make change to more eagerly
rebuild all target outputs in multiple targets:
    https://savannah.gnu.org/bugs/index.php?63098

The recursion here is the following:

- Makefile depends on *.d files
- *.d files depend on *.c files
- *.c files are generated by bison
- bison is triggered whenever some of it's multiple targets are missing

In our case `%.output` is always missing and bison is always reran.
*.d files are always regenerated on `make` run. And make is always
restarted as *.d files are always regenerated.

The fix removes infeasible `%.output`.