### PR TITLE
pylibfdt: fix compatibility with python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ libfdt_module = Extension(
 class build_py(_build_py):
     def run(self):
         self.run_command("build_ext")
-        return super().run()
+        return _build_py.run(self)
 
 setup(
     name='libfdt',


### PR DESCRIPTION
c001fc01a43e ("pylibfdt: fix swig build in install") introduced python3-only super() invocation that fails with python2

  File "setup.py", line 48, in run
    return super().run()
TypeError: super() takes at least 1 argument (0 given)

while setup.py still claims to be compatible with both python versions:

>  While Python 3 is the default, it's also possible to invoke
>  this setup.py script with Python 2.

use legacy syntax that works in all python versions

Fixes: c001fc01a43e ("pylibfdt: fix swig build in install")