### PR TITLE
allow using labels with fdtget/fdtput

### DIFF
--- a/libfdt/fdt_ro.c
+++ b/libfdt/fdt_ro.c
@@ -258,14 +258,18 @@ int fdt_path_offset_namelen(const void *fdt, const char *path, int namelen)
 	if (!can_assume(VALID_INPUT) && namelen <= 0)
 		return -FDT_ERR_BADPATH;
 
-	/* see if we have an alias */
+	/* see if we have an alias or symbol */
 	if (*path != '/') {
 		const char *q = memchr(path, '/', end - p);
 
 		if (!q)
 			q = end;
 
-		p = fdt_get_alias_namelen(fdt, p, q - p);
+		if (*p == '&')
+			p = fdt_get_symbol_namelen(fdt, p + 1, q - p - 1);
+		else
+			p = fdt_get_alias_namelen(fdt, p, q - p);
+
 		if (!p)
 			return -FDT_ERR_BADPATH;
 		offset = fdt_path_offset(fdt, p);

--- a/libfdt/libfdt.h
+++ b/libfdt/libfdt.h
@@ -525,9 +525,10 @@ int fdt_path_offset_namelen(const void *fdt, const char *path, int namelen);
  * address).
  *
  * If the path is not absolute (i.e. does not begin with '/'), the
- * first component is treated as an alias.  That is, the property by
- * that name is looked up in the /aliases node, and the value of that
- * property used in place of that first component.
+ * first component is treated as an alias (or, if it begins with '&',
+ * the rest is treated as a symbol).  That is, the property by that
+ * name is looked up in the /aliases (or /__symbols__) node, and the
+ * value of that property used in place of that first component.
  *
  * For example, for this small fragment
  *
@@ -547,12 +548,17 @@ int fdt_path_offset_namelen(const void *fdt, const char *path, int namelen);
  *
  *   /soc@0/i2c@30a40000/eeprom@52
  *   i2c2/eeprom@52
+ *   &foo/eeprom@52
+ *   &bar
+ *
+ * The latter two only work if the device tree blob has been compiled
+ * with the -@ dtc option.
  *
  * returns:
  *	structure block offset of the node with the requested path (>=0), on
  *		success
  *	-FDT_ERR_BADPATH, given path does not begin with '/' and the first
- *		component is not a valid alias
+ *		component is not a valid alias or symbol
  *	-FDT_ERR_NOTFOUND, if the requested node does not exist
  *      -FDT_ERR_BADMAGIC,
  *	-FDT_ERR_BADVERSION,


### PR DESCRIPTION
It can be convenient and more readable to use `&label` syntax with fdtget and fdtput, rather than having to know the full path. This small series adds that support by hooking into fdt_path_offset_namelen() in the same place where we already allow the first component to be an alias. Of course this only works for blobs that have been built with -@, but it shouldn't affect existing use cases.