### PR TITLE
Fix segmentation fault in check_graph_node and crash in check_graph_child_address

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -1785,31 +1785,6 @@ static void check_graph_nodes(struct check *c, struct dt_info *dti,
 }
 WARNING(graph_nodes, check_graph_nodes, NULL);
 
-static void check_graph_child_address(struct check *c, struct dt_info *dti,
-				      struct node *node)
-{
-	int cnt = 0;
-	struct node *child;
-
-	if (node->bus != &graph_ports_bus && node->bus != &graph_port_bus)
-		return;
-
-	for_each_child(node, child) {
-		struct property *prop = get_property(child, "reg");
-
-		/* No error if we have any non-zero unit address */
-		if (prop && propval_cell(prop) != 0)
-			return;
-
-		cnt++;
-	}
-
-	if (cnt == 1 && node->addr_cells != -1)
-		FAIL(c, dti, node, "graph node has single child node '%s', #address-cells/#size-cells are not necessary",
-		     node->children->name);
-}
-WARNING(graph_child_address, check_graph_child_address, NULL, &graph_nodes);
-
 static void check_graph_reg(struct check *c, struct dt_info *dti,
 			    struct node *node)
 {
@@ -1899,6 +1874,31 @@ static void check_graph_endpoint(struct check *c, struct dt_info *dti,
 		     remote_node->fullpath);
 }
 WARNING(graph_endpoint, check_graph_endpoint, NULL, &graph_nodes);
+
+static void check_graph_child_address(struct check *c, struct dt_info *dti,
+				      struct node *node)
+{
+	int cnt = 0;
+	struct node *child;
+
+	if (node->bus != &graph_ports_bus && node->bus != &graph_port_bus)
+		return;
+
+	for_each_child(node, child) {
+		struct property *prop = get_property(child, "reg");
+
+		/* No error if we have any non-zero unit address */
+                if (prop && propval_cell(prop) != 0 )
+			return;
+
+		cnt++;
+	}
+
+	if (cnt == 1 && node->addr_cells != -1)
+		FAIL(c, dti, node, "graph node has single child node '%s', #address-cells/#size-cells are not necessary",
+		     node->children->name);
+}
+WARNING(graph_child_address, check_graph_child_address, NULL, &graph_nodes, &graph_port, &graph_endpoint);
 
 static struct check *check_table[] = {
 	&duplicate_node_names, &duplicate_property_names,

--- a/livetree.c
+++ b/livetree.c
@@ -441,7 +441,7 @@ cell_t propval_cell(struct property *prop)
 
 cell_t propval_cell_n(struct property *prop, unsigned int n)
 {
-	assert(prop->val.len / sizeof(cell_t) >= n);
+	assert(prop->val.len / sizeof(cell_t) > n);
 	return fdt32_to_cpu(*((fdt32_t *)prop->val.val + n));
 }
 

--- a/tests/bad-graph-child-address.dts
+++ b/tests/bad-graph-child-address.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+ / {
+	bar: bar {
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				bar_con: endpoint {
+					remote-endpoint = <&foo_con>;
+				};
+			};
+		};
+	};
+	foo {
+		port {
+			foo_con: endpoint {
+				remote-endpoint = <&bar_con>;
+			};
+		};
+	};
+};

--- a/tests/bad-graph-reg-cells.dts
+++ b/tests/bad-graph-reg-cells.dts
@@ -1,0 +1,36 @@
+/dts-v1/;
+ / {
+	bar: bar {
+		ports {
+			#address-cells = <1>;
+			#size-cells = <1>; // should always be 0
+			port@1 {
+				reg = <1 2>; // should always contain only a single cell
+				bar_con: endpoint {
+					remote-endpoint = <&foo_con>;
+				};
+			};
+			port@2 {
+				reg = <2>;
+				bar_con2: endpoint {
+					remote-endpoint = <&foo_con2>;
+				};
+			};
+		};
+	};
+	foo {
+		port {
+			#address-cells = <1>;
+			#size-cells = <1>; // should always be 0
+			foo_con: endpoint@1 {
+				reg = <1 2>; // should always contain only a single cell
+				remote-endpoint = <&bar_con>;
+			};
+			foo_con2: endpoint@2 {
+				reg = <2>;
+				remote-endpoint = <&bar_con2>;
+			};
+		};
+
+	};
+};

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -734,6 +734,9 @@ dtc_tests () {
     check_tests "$SRCDIR/bad-graph-root2.dts" graph_nodes
     check_tests "$SRCDIR/bad-graph-root3.dts" graph_nodes
     check_tests "$SRCDIR/bad-graph-root4.dts" graph_nodes
+    check_tests "$SRCDIR/bad-graph-reg-cells.dts" graph_endpoint
+    check_tests "$SRCDIR/bad-graph-reg-cells.dts" graph_port
+    check_tests "$SRCDIR/bad-graph-child-address.dts" graph_child_address
     run_sh_test "$SRCDIR/dtc-checkfails.sh" deprecated_gpio_property -- -Wdeprecated_gpio_property -I dts -O dtb "$SRCDIR/bad-gpio.dts"
     run_sh_test "$SRCDIR/dtc-checkfails.sh" -n deprecated_gpio_property -- -Wdeprecated_gpio_property -I dts -O dtb "$SRCDIR/good-gpio.dts"
     check_tests "$SRCDIR/bad-interrupt-cells.dts" interrupts_property


### PR DESCRIPTION
`check_graph_node()` dereferences `node->parent` without checking whether it is `NULL` first (i.e. the root node).
As a result a segmentation fault occurs for dts files which contain an 'endpoint' node as a direct child of the
root node. This type of error can easily happen when a 'remote-endpoint' property is
accidentally placed outside the corresponding endpoint and port nodes.

Minimal example with 'endpoint' node:
```
/dts-v1/;
/ {	endpoint {};  };
```

Minimal example with remote-endpoint property:
```
/dts-v1/;
/ {
	foo {
                remote-endpoint = <0xdeadbeef>;
	};
};
```
While fixing above issue I ran into an assertion in `check_graph_child_address` which can be triggered with the following example:

```
/dts-v1/;
 / {
	bar: bar {
		port {
			bar_con: endpoint {
				remote-endpoint = <&foo_con>;
			};
		};
	};
	foo {
		port {
			#address-cells = <1>;
			#size-cells = <1>; // should always be 0
			foo_con: endpoint@1 {
				reg = <1 2>; // causes assertion failure instead of diagnostic
				remote-endpoint = <&bar_con>;
			};
		};
	};
};
```

The condition that triggers this issue is actually caught by `check_graph_port()`, however `check_graph_child_address()` runs first hiding the warning.