### PR TITLE
libfdt: overlay: Skip phandles not in subnodes

### DIFF
--- a/libfdt/fdt_overlay.c
+++ b/libfdt/fdt_overlay.c
@@ -540,7 +540,8 @@ static int overlay_fixup_phandles(void *fdt, void *fdto)
  *      Negative error code on failure
  */
 static int overlay_apply_node(void *fdt, int target,
-			      void *fdto, int node)
+			      void *fdto, int node,
+			      int depth)
 {
 	int property;
 	int subnode;
@@ -557,6 +558,9 @@ static int overlay_apply_node(void *fdt, int target,
 			return -FDT_ERR_INTERNAL;
 		if (prop_len < 0)
 			return prop_len;
+		if ((depth == 0) && ((strcmp(name, "phandle") == 0) ||
+				     (strcmp(name, "linux,phandle") == 0)))
+			continue;
 
 		ret = fdt_setprop(fdt, target, name, prop, prop_len);
 		if (ret)
@@ -578,7 +582,7 @@ static int overlay_apply_node(void *fdt, int target,
 		if (nnode < 0)
 			return nnode;
 
-		ret = overlay_apply_node(fdt, nnode, fdto, subnode);
+		ret = overlay_apply_node(fdt, nnode, fdto, subnode, depth + 1);
 		if (ret)
 			return ret;
 	}
@@ -625,7 +629,7 @@ static int overlay_merge(void *fdt, void *fdto)
 		if (target < 0)
 			return target;
 
-		ret = overlay_apply_node(fdt, target, fdto, overlay);
+		ret = overlay_apply_node(fdt, target, fdto, overlay, 0);
 		if (ret)
 			return ret;
 	}


### PR DESCRIPTION
A Raspberry Pi user reported (https://github.com/raspberrypi/firmware/issues/1718) that some overlays that work with the Pi tools can't be applied by fdtoverlay (even ignoring the non-standard parameter stuff). After some digging I traced the problem to unwanted phandles being copied into the base dtb, overwriting an existing phandle and breaking references to that node.

This patch filters out phandles in the outer level of __overlay__ nodes (i.e. not in subnodes).