### PR TITLE
overlay: ensure that existing phandles are not overwritten

### DIFF
--- a/tests/overlay_base_phandle.dts
+++ b/tests/overlay_base_phandle.dts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 Uwe Kleine-König
+ *
+ * SPDX-License-Identifier:	GPL-2.0+
+ */
+
+/dts-v1/;
+
+/ {
+	node_a: a {
+		value = <17>;
+	};
+
+	node_b: b {
+		a = <&node_a>;
+	};
+
+	node_c: c {
+		b = <&node_b>;
+	};
+};

--- a/tests/overlay_overlay_phandle.dts
+++ b/tests/overlay_overlay_phandle.dts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 Uwe Kleine-König
+ *
+ * SPDX-License-Identifier:	GPL-2.0+
+ */
+
+/dts-v1/;
+/plugin/;
+
+&{/} {
+	/* /a already has a label "node_a" in the base dts */
+	node_b2: b {
+		value = <42>;
+		c = <&node_c>;
+	};
+
+	c {
+		b = <&node_b2>;
+		a = <&node_a>;
+		d = <&node_d>;
+	};
+
+	node_d: d {
+		value = <23>;
+	};
+};
+
+&node_a {
+	value = <32>;
+};

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1035,6 +1035,21 @@ fdtoverlay_tests() {
     run_dtc_test -@ -I dts -O dtb -o $stacked_addlabeldtb $stacked_addlabel
 
     run_fdtoverlay_test baz "/foonode/barnode/baznode" "baz-property" "-ts" ${stacked_base_nolabeldtb} ${stacked_addlabel_targetdtb} ${stacked_addlabeldtb} ${stacked_bardtb} ${stacked_bazdtb}
+
+    # verify that labels are not overwritten
+    run_dtc_test -@ -I dts -O dtb -o overlay_base_phandle.test.dtb "$SRCDIR/overlay_base_phandle.dts"
+    run_dtc_test -@ -I dts -O dtb -o overlay_overlay_phandle.test.dtb "$SRCDIR/overlay_overlay_phandle.dts"
+    run_wrap_test $FDTOVERLAY -i overlay_base_phandle.test.dtb -o overlay_base_phandleO.test.dtb overlay_overlay_phandle.test.dtb
+
+    pa=$($DTGET overlay_base_phandleO.test.dtb /a phandle)
+    ba=$($DTGET overlay_base_phandleO.test.dtb /b a)
+    ca=$($DTGET overlay_base_phandleO.test.dtb /c a)
+    shorten_echo "check phandle wasn't overwritten:	"
+    if test "$ba$ca" = "$pa$pa"; then
+	    PASS
+    else
+	    FAIL
+    fi
 }
 
 pylibfdt_tests () {


### PR DESCRIPTION
A phandle in an overlay is not supposed to overwrite a phandle that already exists in the base dtb as this breaks references to the respective node in the base.

Traditionally all phandle values in the overlay were increased by a fixed offset such that the base and overlay handle values don't overlap. With this change the overlay's phandles are determined dynamically. Already existing phandles are kept and an array "phandlemap" is used to track how the overlay's phandles change.

overlay_adjust_local_phandles() which creates the mapping between old and new phandles in the overlay needs to check the nodes in the base. To be able to find the base's node, overlay_fixup_phandles() must be run first, so the order of functions fdt_overlay_apply() had to change.

A test is added that checks that newly added phandles and existing phandles work as expected.