### PR TITLE
dtc: Add an option to generate __local_fixups__ and __fixups__

### DIFF
--- a/Documentation/manual.txt
+++ b/Documentation/manual.txt
@@ -126,6 +126,20 @@ Options:
 	property for each label. The property's name is the label name and the
 	value is the path of the labeled node.
 
+    -L
+	Possibly generates a __local_fixups__ and a __fixups__ node at the root node.
+	For each property that contains a phandle reference using a locally
+	defined phandle, the __local_fixups__ node contains a property (at path
+	/__local_fixups__/$a if $a is the path of the node). Its value is a list
+	of offsets that are phandle values. If there are no such properties, no
+	__local_fixups__ node is generated.
+	For each undefined label used in at least one reference, the __fixups__
+	node contains a property. Its name is the label name, its value is a
+	list of locations where the label is used in a reference in the format
+	"path:property:offset". If there is no undefined label, no __fixups__
+	nodes is generated.
+	Enabled by default for compiling overlays (i.e. dts files with a
+	/plugin/ tag).
 
     -A
 	Generate automatically aliases for all node labels. This is similar to

--- a/dtc.c
+++ b/dtc.c
@@ -47,7 +47,7 @@ static void fill_fullpaths(struct node *tree, const char *prefix)
 
 /* Usage related data. */
 static const char usage_synopsis[] = "dtc [options] <input file>";
-static const char usage_short_opts[] = "qI:O:o:V:d:R:S:p:a:fb:i:H:sW:E:@AThv";
+static const char usage_short_opts[] = "qI:O:o:V:d:R:S:p:a:fb:i:H:sW:E:@LAThv";
 static struct option const usage_long_opts[] = {
 	{"quiet",            no_argument, NULL, 'q'},
 	{"in-format",         a_argument, NULL, 'I'},
@@ -67,6 +67,7 @@ static struct option const usage_long_opts[] = {
 	{"warning",           a_argument, NULL, 'W'},
 	{"error",             a_argument, NULL, 'E'},
 	{"symbols",	     no_argument, NULL, '@'},
+	{"local-fixups",     no_argument, NULL, 'L'},
 	{"auto-alias",       no_argument, NULL, 'A'},
 	{"annotate",         no_argument, NULL, 'T'},
 	{"help",             no_argument, NULL, 'h'},
@@ -252,6 +253,11 @@ int main(int argc, char *argv[])
 		case '@':
 			generate_symbols = 1;
 			break;
+
+		case 'L':
+			generate_fixups = 1;
+			break;
+
 		case 'A':
 			auto_label_aliases = 1;
 			break;


### PR DESCRIPTION
This records detailed usage of labels in a dtb. This is needed in overlays (and enabled implicitly for these). For ordinary device trees it can be used to restore labels when compiling back to dts format.

This patch was also sent to the devicetree-compiler ML and corresponds to v3 with Message-Id: <20230523080941.419330-1-u.kleine-koenig@pengutronix.de>. Copied it to here to benefit from the ci tests and maybe make it easier to merge.