### PR TITLE
Fix use of <ctype.h> functions

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -1182,7 +1182,7 @@ static void check_unit_address_format(struct check *c, struct dt_info *dti,
 		/* skip over 0x for next test */
 		unitname += 2;
 	}
-	if (unitname[0] == '0' && isxdigit(unitname[1]))
+	if (unitname[0] == '0' && isxdigit((unsigned char)unitname[1]))
 		FAIL(c, dti, node, "unit name should not have leading 0s");
 }
 WARNING(unit_address_format, check_unit_address_format, NULL,

--- a/yamltree.c
+++ b/yamltree.c
@@ -102,7 +102,7 @@ static void yaml_propval_string(yaml_emitter_t *emitter, char *str, int len)
 
 	/* Make sure the entire string is in the lower 7-bit ascii range */
 	for (i = 0; i < len; i++)
-		assert(isascii(str[i]));
+		assert(isascii((unsigned char)str[i]));
 
 	yaml_scalar_event_initialize(&event, NULL,
 		(const yaml_char_t *)YAML_STR_TAG, (const yaml_char_t*)str,


### PR DESCRIPTION
The value passed to the <ctype.h> functions shall be the value of an unsigned char or EOF.  It is implementation-defined if the char type is signed or unsigned.  Cast to unsigned char to avoid undefined behaviour on systems where char is signed.

This cast is already present in other parts of the code base.

Close #71.