### PR TITLE
meson: set minimum Meson version to 0.56.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project('dtc', 'c',
   version: '1.7.0',
   license: ['GPL2+', 'BSD-2'],
   default_options: 'werror=true',
+  meson_version: '>=0.56.0'
 )
 
 cc = meson.get_compiler('c')


### PR DESCRIPTION
Set the minimum required version of Meson based on the highest version feature used, as detected by meson-setup.

* 0.50.0: {'Python module path method', 'include_directories kwarg of type string'}