### PR TITLE
libfdt: fix library version to match project version

### DIFF
--- a/libfdt/meson.build
+++ b/libfdt/meson.build
@@ -28,7 +28,7 @@ endif
 link_args += version_script
 libfdt = library(
   'fdt', sources,
-  version: '1.6.0',
+  version: meson.project_version(),
   link_args: link_args,
   link_depends: 'version.lds',
   install: true,


### PR DESCRIPTION
Build the libfdt with the correct version number by pulling the version from the top-level project.

Change as suggested from https://github.com/dgibson/dtc/pull/95#issuecomment-1546933095