### PR TITLE
fix use of deprecated Meson methods

### DIFF
--- a/pylibfdt/meson.build
+++ b/pylibfdt/meson.build
@@ -1,5 +1,5 @@
 setup_py = find_program('../setup.py')
-setup_py = [setup_py.path(), '--quiet', '--top-builddir', meson.project_build_root()]
+setup_py = [setup_py, '--quiet', '--top-builddir', meson.project_build_root()]
 
 custom_target(
   'pylibfdt',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -120,8 +120,8 @@ if not py.found()
   env += 'NO_PYTHON=1'
 else
   env += [
-    'PYTHON=' + py.path(),
-    'PYTHONPATH=' + meson.source_root() / 'pylibfdt',
+    'PYTHON=' + py.full_path(),
+    'PYTHONPATH=' + meson.project_source_root() / 'pylibfdt',
   ]
 endif
 if not yaml.found()


### PR DESCRIPTION
tests: fix use of deprecated meson methods

> tests/meson.build:123: WARNING: Project targets '>=0.56.0' but uses
  feature deprecated since '0.55.0': ExternalProgram.path. use
  ExternalProgram.full_path() instead
> tests/meson.build:124: WARNING: Project targets '>=0.56.0' but uses
  feature deprecated since '0.56.0': meson.source_root. use
  meson.project_source_root() or meson.global_source_root() instead.

pylibtfdt: fix use of deprecated meson method

> pylibfdt/meson.build:2: WARNING: Project targets '>=0.56.0' but uses
  feature deprecated since '0.55.0': ExternalProgram.path. use
  ExternalProgram.full_path() instead

Do not use full_path() as suggested. setup_py is being called as a
command by custom_target() which understands how to properly inherit the
object returned by find_program().
