### PR TITLE
tests: generate dtbs in Meson build directory

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -373,9 +373,10 @@ tree1_tests_rw () {
 check_tests () {
     tree="$1"
     shift
+    dtb=$(basename "$tree" .dts).test.dtb
     run_sh_test "$SRCDIR/dtc-checkfails.sh" "$@" -- -I dts -O dtb $tree
-    run_dtc_test -I dts -O dtb -o $tree.test.dtb -f $tree
-    run_sh_test "$SRCDIR/dtc-checkfails.sh" "$@" -- -I dtb -O dtb $tree.test.dtb
+    run_dtc_test -I dts -O dtb -o "$dtb" -f $tree
+    run_sh_test "$SRCDIR/dtc-checkfails.sh" "$@" -- -I dtb -O dtb "$dtb"
 }
 
 ALL_LAYOUTS="mts mst tms tsm smt stm"


### PR DESCRIPTION
When running under Meson, check_tests() is generating dtb build files in
the source directory. This is because dtb is named by appending
".test.dtb" to the full source file name.

Use basename to extract just the source filename and write it to the
working directory which is the build directory.