### PR TITLE
libfdt: add missing version symbols

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,6 @@ indent_size = 4
 [meson.build]
 indent_style = space
 indent_size = 2
+
+[*.lds]
+indent_style = tab

--- a/libfdt/version.lds
+++ b/libfdt/version.lds
@@ -78,6 +78,8 @@ LIBFDT_1.2 {
 		fdt_setprop_inplace_namelen_partial;
 		fdt_create_with_flags;
 		fdt_overlay_target_offset;
+		fdt_get_symbol;
+		fdt_get_symbol_namelen;
 	local:
 		*;
 };

--- a/libfdt/version.lds
+++ b/libfdt/version.lds
@@ -20,7 +20,7 @@ LIBFDT_1.2 {
 		fdt_get_alias_namelen;
 		fdt_get_alias;
 		fdt_get_path;
-                fdt_header_size;
+		fdt_header_size;
 		fdt_supernode_atdepth_offset;
 		fdt_node_depth;
 		fdt_parent_offset;


### PR DESCRIPTION
> libfdt: add missing version symbols
> 
> These symbols were not added to the version script when they were added
> to libfdt.

> editorconfig: use tab indentation for version.lds
> 
> This file is indented with tabs, but editorconfig defaults all files to
> spaces.

Covers symbols that would be added by https://github.com/dgibson/dtc/pull/108