### PR TITLE
version_get.h: add missing info in Meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,6 +59,11 @@ py = py.find_installation(required: get_option('python'))
 swig = find_program('swig', required: get_option('python'))
 
 version_gen_h = vcs_tag(
+  command: [
+    'scripts/setlocalversion',
+    meson.current_source_dir(),
+    meson.project_version()
+  ],
   input: 'version_gen.h.in',
   output: 'version_gen.h',
 )

--- a/scripts/setlocalversion
+++ b/scripts/setlocalversion
@@ -3,11 +3,15 @@
 # Print additional version information for non-release trees.
 
 usage() {
-	echo "Usage: $0 [srctree]" >&2
+	echo "Usage: $0 [srctree] [version]" >&2
 	exit 1
 }
 
 cd "${1:-.}" || usage
+
+if [ -n "${2}" ]; then
+        printf '%s' "${2}"
+fi
 
 # Check for git and a git repo.
 if head=`git rev-parse --verify HEAD 2>/dev/null`; then


### PR DESCRIPTION
The Makefile calls the setlocalversion script to get the repo info, append it to the version, and add it to version_gen.h. Meson is skipping the repo info and just writing the version into version_gen.h.

The Meson vcs_tag() can call an external program to get the version, but it can't append the output to another string, so we must update setlocalversion to do it for us.