### PR TITLE
github: add workflow for Meson builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ name: Build test
       - main
 
 jobs:
-  build:
+  build-make:
     runs-on: ubuntu-latest
 
     strategy:
@@ -35,3 +35,31 @@ jobs:
       - name: Run check
         run: |
           make check
+
+  build-meson:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+          os: [ "alpine", "archlinux", "fedora", "ubuntu" ]
+
+    container:
+      image: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: |
+          ./scripts/install-deps.sh
+
+      - name: Setup
+        run: meson setup build
+
+      - name: Build
+        run: meson compile -C build
+
+      - name: Run check
+        run: meson test -C build

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -12,20 +12,20 @@ fi
 if [ "$NAME" = "Arch Linux" ]
 then
     pacman -Syu --needed --noconfirm bison diffutils flex gcc git libyaml \
-    make pkgconf python python-setuptools-scm swig valgrind which
+    make meson pkgconf python python-setuptools-scm swig valgrind which
 elif [ "$NAME" = "Alpine Linux" ]
 then
     apk add build-base bison coreutils flex git yaml yaml-dev python3-dev \
-    py3-setuptools_scm swig valgrind
+    meson py3-setuptools_scm swig valgrind
 elif [ "$NAME" = "Fedora Linux" ]
 then
     dnf install -y bison diffutils flex gcc git libyaml libyaml-devel \
-    make python3-devel python3-setuptools swig valgrind which
+    make meson python3-devel python3-setuptools swig valgrind which
 elif [ "$NAME" = "Ubuntu" ]
 then
     apt update
     apt install -yq build-essential bison flex git libyaml-dev pkg-config \
-    python3-dev python3-setuptools python3-setuptools-scm swig valgrind
+    meson python3-dev python3-setuptools python3-setuptools-scm swig valgrind
 else
     echo "ERROR: OS name is not provided."
     exit 1


### PR DESCRIPTION
This pull request is based on #110 

This does not enable the flag "--fatal-meson-warnings" for meson-setup. There is an issue with setup on the Ubuntu builder that causes this warning.

> WARNING: Broken python installation detected. Python files installed
    by Meson might not be found by python interpreter.

The issue appears to be a false-positive on Debian-based distros, introduced in Meson 0.60.0 and fixed in 0.61.5 and 0.62.0. But the Ubuntu builder currently uses 0.61.3.
See this discussion for more detail https://gitlab.com/qemu-project/qemu/-/issues/873
