### PR TITLE
Revert "dtc: Consider one-character strings as strings"

### DIFF
--- a/treesource.c
+++ b/treesource.c
@@ -162,7 +162,7 @@ static enum markertype guess_value_type(struct property *prop)
 			nnotcelllbl++;
 	}
 
-	if ((p[len-1] == '\0') && (nnotstring == 0) && (nnul <= (len-nnul))
+	if ((p[len-1] == '\0') && (nnotstring == 0) && (nnul < (len-nnul))
 	    && (nnotstringlbl == 0)) {
 		return TYPE_STRING;
 	} else if (((len % sizeof(cell_t)) == 0) && (nnotcelllbl == 0)) {


### PR DESCRIPTION
This reverts commit 9d7888cbf19c2930992844e69a097dc71e5a7354.

This commit broke decompilation in certain cases. For example:
   regulator-min-microvolt = <0x00324b00>;
is now decompiled (incorrectly) as:
   regulator-min-microvolt = "\02K";