### PR TITLE
meson: allow building from shallow clones

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,6 +59,7 @@ py = py.find_installation(required: get_option('python'))
 swig = find_program('swig', required: get_option('python'))
 
 version_gen_h = vcs_tag(
+  command: ['git', 'describe', '--dirty=+'],
   input: 'version_gen.h.in',
   output: 'version_gen.h',
 )


### PR DESCRIPTION
Shallow clones are useful for air-gapped build environments and to ensure various compliance tasks.

When building from shallow clone, tag is not available and version defaults to git hash.
Problem is that some builds check DTC version and fail the comparison. Example is https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git Which fails to build with following error:
dtc version too old (039a994), you need at least version 1.4.4

Drop --always from git describe command, see
https://github.com/mesonbuild/meson/blob/1.3.0/mesonbuild/utils/universal.py#L773 This will make it more closer to build via Makefile.