### PR TITLE
fix MinGW format attribute

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,13 +22,6 @@ add_project_arguments(
   language: 'c'
 )
 
-if host_machine.system() == 'windows'
-  add_project_arguments(
-    '-D__USE_MINGW_ANSI_STDIO=1',
-    language: 'c'
-  )
-endif
-
 add_project_arguments(
   '-DFDT_ASSUME_MASK=' + get_option('assume-mask').to_string(),
   language: 'c'

--- a/util.h
+++ b/util.h
@@ -13,7 +13,9 @@
  */
 
 #ifdef __GNUC__
-#if __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
+#ifdef __MINGW_PRINTF_FORMAT
+#define PRINTF(i, j)	__attribute__((format (__MINGW_PRINTF_FORMAT, i, j)))
+#elif __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
 #define PRINTF(i, j)	__attribute__((format (gnu_printf, i, j)))
 #else
 #define PRINTF(i, j)	__attribute__((format (printf, i, j)))


### PR DESCRIPTION
Setting -D__USE_MINGW_ANSI_STDIO=1 is wrong and should not be used. MinGW internally uses a macro to select between gnu_printf and printf. Just use that instead of using a wrong format under clang backends.