### PR TITLE
github: enforce testing pylibfdt and yaml support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          os: [ "alpine", "archlinux", "fedora", "ubuntu" ]
+          os: [ "alpine", "archlinux", "fedora", "ubuntu:23.10" ]
 
     container:
       image: ${{ matrix.os }}
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          os: [ "alpine", "archlinux", "fedora", "ubuntu" ]
+          os: [ "alpine", "archlinux", "fedora", "ubuntu:23.10" ]
 
     container:
       image: ${{ matrix.os }}
@@ -62,7 +62,7 @@ jobs:
           ./scripts/install-deps.sh
 
       - name: Setup
-        run: meson setup build
+        run: meson setup -D python=enabled -D yaml=enabled build
 
       - name: Build
         run: meson compile -C build


### PR DESCRIPTION
The Ubuntu runner was not building the yaml support as it's using Ubuntu 22 (jammy) which uses libyaml 0.2.2, but the build requires libyaml 0.2.3. Switch to Ubuntu 23 which has libyaml 0.2.5.

This was not detected by the runner as the Yaml feature defaults to "auto" which turns off if it fails to find the dependency. In the runner force yaml to enabled so if it fails to build it will trigger a build failure.

We also force python support for the same reason.