### PR TITLE
meson: fix dependencies of tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,7 @@ endif
 py = import('python')
 py = py.find_installation(required: get_option('python'))
 swig = find_program('swig', required: get_option('python'))
+pylibfdt_enabled = not meson.is_cross_build() and py.found() and swig.found() ? true : false
 
 version_gen_h = vcs_tag(
   command: ['git', 'describe', '--dirty=+'],
@@ -59,6 +60,7 @@ version_gen_h = vcs_tag(
 
 subdir('libfdt')
 
+dtc_tools = []
 if get_option('tools')
   flex = find_program('flex', required: true)
   bison = find_program('bison', required: true)
@@ -82,7 +84,7 @@ if get_option('tools')
   )
 
   if cc.check_header('fnmatch.h')
-    executable(
+    dtc_tools += executable(
       'convert-dtsv0',
       [
         lgen.process('convert-dtsv0-lexer.l'),
@@ -94,7 +96,7 @@ if get_option('tools')
     )
   endif
 
-  executable(
+  dtc_tools += executable(
     'dtc',
     [
       lgen.process('dtc-lexer.l'),
@@ -115,7 +117,7 @@ if get_option('tools')
   )
 
   foreach e: ['fdtdump', 'fdtget', 'fdtput', 'fdtoverlay']
-    executable(e, files(e + '.c'), dependencies: util_dep, install: true, link_args: extra_link_args)
+    dtc_tools += executable(e, files(e + '.c'), dependencies: util_dep, install: true, link_args: extra_link_args)
   endforeach
 
   install_data(
@@ -125,10 +127,8 @@ if get_option('tools')
   )
 endif
 
-if not meson.is_cross_build()
-  if py.found() and swig.found()
-    subdir('pylibfdt')
-  endif
+if pylibfdt_enabled
+  subdir('pylibfdt')
 endif
 
 if get_option('tests')

--- a/pylibfdt/meson.build
+++ b/pylibfdt/meson.build
@@ -1,7 +1,7 @@
 setup_py = find_program('../setup.py')
 setup_py = [setup_py, '--quiet', '--top-builddir', meson.project_build_root()]
 
-custom_target(
+pylibfdt = custom_target(
   'pylibfdt',
   input: 'libfdt.i',
   output: '_libfdt.so',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -109,8 +109,9 @@ if not static_build
   test_deps += [dl]
 endif
 
+tests_exe = []
 foreach t: tests
-  executable(t, files(t + '.c'), dependencies: test_deps, link_args: extra_link_args)
+  tests_exe += executable(t, files(t + '.c'), dependencies: test_deps, link_args: extra_link_args)
 endforeach
 
 run_tests = find_program('run_tests.sh')
@@ -128,11 +129,17 @@ if not yaml.found()
   env += 'NO_YAML=1'
 endif
 
+run_test_deps = [
+  dtc_tools, dumptrees_dtb, tests_exe
+]
+if pylibfdt_enabled
+  run_test_deps += pylibfdt
+endif
 test(
   'run-test',
   run_tests,
   workdir: meson.current_build_dir(),
-  depends: dumptrees_dtb,
+  depends: run_test_deps,
   env: env,
   timeout: 1800, # mostly for valgrind
 )

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -129,17 +129,32 @@ if not yaml.found()
   env += 'NO_YAML=1'
 endif
 
+run_test_types = [
+  'libfdt',
+  'utilfdt',
+  'dtc',
+  'dtbs_equal',
+  'fdtget',
+  'fdtput',
+  'fdtdump',
+  'fdtoverlay'
+]
 run_test_deps = [
   dtc_tools, dumptrees_dtb, tests_exe
 ]
 if pylibfdt_enabled
+  run_test_types += 'pylibfdt'
   run_test_deps += pylibfdt
 endif
-test(
-  'run-test',
-  run_tests,
-  workdir: meson.current_build_dir(),
-  depends: run_test_deps,
-  env: env,
-  timeout: 1800, # mostly for valgrind
-)
+foreach test_type : run_test_types
+  test(
+    test_type,
+    run_tests,
+    args: ['-t', test_type],
+    is_parallel: false,
+    workdir: meson.current_build_dir(),
+    depends: run_test_deps,
+    env: env,
+    timeout: 1800, # mostly for valgrind
+  )
+endforeach


### PR DESCRIPTION
meson: fix dependencies of tests

    If the tests are run without a full compile they will fail. For example
    with the following.

    > rm -rf build/
    > meson setup build/
    > meson test -C build/

    This is because the tests rely on the devicetree tools and test
    executables.



meson: split run-tests by type

    Instead of running run-tests on all tests, split them down into the 9
    separate run-tests test types. This provides better granularity of test
    results from the Meson test harness.

