### PR TITLE
libfdt: overlay: Refactor overlay_fixup_phandle and update test case

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -269,7 +269,7 @@ libfdt_overlay_tests () {
     for test in $BAD_FIXUP_TREES; do
 	tree="overlay_bad_fixup_$test"
 	run_dtc_test -I dts -O dtb -o $tree.test.dtb "$SRCDIR/$tree.dts"
-	run_test overlay_bad_fixup overlay_base_no_symbols.test.dtb $tree.test.dtb
+	run_test overlay_bad_fixup overlay_base_manual_symbols.test.dtb $tree.test.dtb
     done
     run_sh_test "$SRCDIR/dtc-fatal.sh" -I dts -O dtb -o /dev/null "$SRCDIR/fixup-ref-to-path.dts"
 }


### PR DESCRIPTION
This commit makes two main changes:
1. Refactored overlay_fixup_phandle to optimize efficiency by moving the phandle lookup logic based on label outside the overlay_fixup_one_phandle call. This avoids redundant phandle lookups when a single label is associated with multiple modifications.

2. Updated the test case for overlay_bad_fixup. Changed the target DTS from overlay_base_no_symbols.test.dtb to overlay_base_manual_symbols.test.dtb. This ensures that the test case doesn't exit prematurely due to the absence of label-linked phandle in the __symbols__ node. The update guarantees that the test case appropriately checks the validity of the fixup string linked to the label, as intended.