### PR TITLE
pylibfdt/meson.build: fix Python library being rebuilt during install

### DIFF
--- a/pylibfdt/Makefile.pylibfdt
+++ b/pylibfdt/Makefile.pylibfdt
@@ -17,7 +17,7 @@ endif
 
 $(PYMODULE): $(PYLIBFDT_srcs) $(LIBFDT_archive) $(SETUP)
 	@$(VECHO) PYMOD $@
-	$(PYTHON) $(SETUP) $(SETUPFLAGS) build_ext --build-lib=$(PYLIBFDT_dir)
+	$(PYTHON) $(SETUP) $(SETUPFLAGS) build_ext
 
 install_pylibfdt: $(PYMODULE)
 	@$(VECHO) INSTALL-PYLIB

--- a/pylibfdt/meson.build
+++ b/pylibfdt/meson.build
@@ -6,7 +6,7 @@ pylibfdt = custom_target(
   input: 'libfdt.i',
   depends: libfdt,
   output: '_libfdt.so',
-  command: [setup_py, 'build_ext', '--build-lib=' + meson.current_build_dir()],
+  command: [setup_py, 'build_ext'],
   build_by_default: true,
 )
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -18,7 +18,9 @@ if [ -n "$NO_PYTHON" ]; then
         no_python=false
     fi
 else
-    if [ -f ../pylibfdt/_libfdt.so ] || [ -f ../pylibfdt/_libfdt.cpython-3*.so ]; then
+    if [ -f ../pylibfdt/_libfdt.so ] \
+            || [ -f ../pylibfdt/_libfdt.cpython-3*.so ] \
+            || [ -f ../build/lib.*/_libfdt.cpython-3*.so ]; then
         no_python=false
     else
         no_python=true
@@ -56,6 +58,16 @@ if [ -z "$TEST_LIBDIR" ]; then
     TEST_LIBDIR=../libfdt
 fi
 export LD_LIBRARY_PATH="$TEST_LIBDIR"
+
+# Find the python module that distutils builds under a machine-specific path
+PYLIBFDT_BUILD=$(echo ../build/lib.*)
+if [ -e "$PYLIBFDT_BUILD" ]; then
+    if [ -n "$PYTHONPATH" ]; then
+        export PYTHONPATH="$PYTHONPATH:$PYLIBFDT_BUILD"
+    else
+        export PYTHONPATH="$PYLIBFDT_BUILD"
+    fi
+fi
 
 export QUIET_TEST=1
 STOP_ON_FAIL=0


### PR DESCRIPTION
User @sharkcz noted that when the '--quiet' flag is removed from ./setup.py, the following can be seen from the `./setup.py install` stage.

```
  Running custom install script 'dtc/g/pylibfdt/../setup.py --top-builddir \
    dtc/g/redhat-linux-build install --prefix=/usr/local --root=$DESTDIR'
  running install
  ...
  building '_libfdt' extension
  swigging dtc/g/pylibfdt/../pylibfdt/libfdt.i to \
    dtc/g/pylibfdt/../pylibfdt/libfdt_wrap.c
  swig -python -Idtc/g/pylibfdt/../libfdt -o \
    dtc/g/pylibfdt/../pylibfdt/libfdt_wrap.c dtc/g/pylibfdt/../pylibfdt/libfdt.i
  gcc -fno-strict-overflow -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 \
    -DNDEBUG -fexceptions -fexceptions -fexceptions -fPIC -DPY_SSIZE_T_CLEAN \
    -Idtc/g/pylibfdt/../libfdt -I/usr/include/python3.12 -c \
    dtc/g/pylibfdt/../pylibfdt/libfdt_wrap.c -o \
    build/temp.linux-ppc64le-cpython-312dtc/g/pylibfdt/../pylibfdt/libfdt_wrap.o
  creating build/lib.linux-ppc64le-cpython-312
  gcc -shared build/temp.linux-ppc64le-cpython-312dtc/g/pylibfdt/../pylibfdt/libfdt_wrap.o \
    -Ldtc/g/redhat-linux-build/libfdt -L/usr/lib64 -lfdt -o \
    build/lib.linux-ppc64le-cpython-312/_libfdt.cpython-312-powerpc64le-linux-gnu.so
  copying dtc/g/pylibfdt/../pylibfdt/libfdt.py -> build/lib.linux-ppc64le-cpython-312

```
Meaning the python library is getting recompiled during the `meson install` phase. This causes build issues as Meson does not set the compiler and linker flags during the install phase.

The reason the library is getting rebuilt is during the normal build with "build_ext", the `--build-lib` flag gets passed which changes the default output build directory. But there is no equivalent option for the "install" command. Install instead looks in the default directory "./build" and so does not find the previously built library.

Since we can't fix the "install" command, drop the --build-lib flag. This causes setup.py to compile the libraries at
`<meson-build>/build/lib.linux-x86_64-cpython-312/`. We must also then fix run_tests.sh to find the library build directory as it's machine-dependent.

Fixes: #135