### PR TITLE
tests/meson.build: fix python and yaml tests not running

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -123,10 +123,13 @@ else
   env += [
     'PYTHON=' + py.full_path(),
     'PYTHONPATH=' + meson.project_source_root() / 'pylibfdt',
+    'NO_PYTHON=0',
   ]
 endif
 if not yaml.found()
   env += 'NO_YAML=1'
+else
+  env += 'NO_YAML=0'
 endif
 
 run_test_types = [


### PR DESCRIPTION
The run-tests.sh script attempts to detect if Python and Yaml support is enabled in the build. This has caused false-negatives where it fails to find the Python library even though it was compiled into the build.

Avoid this problem altogether and always set the NO_PYTHON and NO_YAML to match if the features are enabled in Meson.