### PR TITLE
pylibfdt/Makefile.pylibfdt: use project's flags to compile the extension

### DIFF
--- a/pylibfdt/Makefile.pylibfdt
+++ b/pylibfdt/Makefile.pylibfdt
@@ -17,7 +17,7 @@ endif
 
 $(PYMODULE): $(PYLIBFDT_srcs) $(LIBFDT_archive) $(SETUP)
 	@$(VECHO) PYMOD $@
-	$(PYTHON) $(SETUP) $(SETUPFLAGS) build_ext
+	CFLAGS="$(CFLAGS) -Wno-error" $(PYTHON) $(SETUP) $(SETUPFLAGS) build_ext
 
 install_pylibfdt: $(PYMODULE)
 	@$(VECHO) INSTALL-PYLIB


### PR DESCRIPTION
Seems the project's CFLAGS are not used when compiling the python extension's C code via the setup.py script. Some default flags are used instead. Thus pass the CFLAGS explicitly. Unfortunately the SWIG generated code is not clean and requires `-Wno-error` override to compile successfully, because `-Werror` is used in the project's flags.