### PR TITLE
meson: fix installation with meson-python

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -122,7 +122,7 @@ if get_option('tools')
 
   install_data(
     'dtdiff',
-    install_dir: get_option('prefix') / get_option('bindir'),
+    install_dir: get_option('bindir'),
     install_mode: 'rwxr-xr-x',
   )
 endif


### PR DESCRIPTION
The meson-python backend fails to map 'dtdiff' install into Python wheels. Removing the prefix from the install_dir path allows meson-python to map dtdiff. The install_data(install_dir) documentation says "If this is a relative path, it is assumed to be relative to the prefix"[1]. So removing the prefix does not change the installation behaviour.

[1] https://mesonbuild.com/Reference-manual_functions.html#install_data