### PR TITLE
libfdt: allow building only static or shared libraries

### DIFF
--- a/libfdt/meson.build
+++ b/libfdt/meson.build
@@ -26,7 +26,7 @@ else
 endif
 
 link_args += version_script
-libfdt = both_libraries(
+libfdt = library(
   'fdt', sources,
   version: meson.project_version(),
   link_args: link_args,
@@ -34,18 +34,24 @@ libfdt = both_libraries(
   install: true,
 )
 
-if static_build
-  link_with = libfdt.get_static_lib()
-else
-  link_with = libfdt.get_shared_lib()
-endif
-
 libfdt_inc = include_directories('.')
 
 libfdt_dep = declare_dependency(
   include_directories: libfdt_inc,
-  link_with: link_with,
+  link_with: libfdt,
 )
+
+if static_build
+  libfdt_static_dep = declare_dependency(
+    include_directories: libfdt_inc,
+  )
+  libfdt_static_objs = libfdt.extract_all_objects()
+else
+  libfdt_static_dep = declare_dependency(
+    dependencies: libfdt_dep
+  )
+  libfdt_static_objs = []
+endif
 
 install_headers(
   files(

--- a/meson.build
+++ b/meson.build
@@ -27,16 +27,11 @@ add_project_arguments(
   language: 'c'
 )
 
-if get_option('static-build')
-  static_build = true
-  extra_link_args = ['-static']
-else
-  static_build = false
-  extra_link_args = []
-endif
+static_build = get_option('static-build')
+static_kwargs = static_build ? {'static': true} : {}
 
 yamltree = 'yamltree.c'
-yaml = dependency('yaml-0.1', version: '>=0.2.3', required: get_option('yaml'), static: static_build)
+yaml = dependency('yaml-0.1', version: '>=0.2.3', required: get_option('yaml'), kwargs: static_kwargs)
 if not yaml.found()
   add_project_arguments('-DNO_YAML', language: 'c')
   yamltree = []
@@ -68,7 +63,7 @@ if get_option('tools')
   util_dep = declare_dependency(
     sources: ['util.c', version_gen_h],
     include_directories: '.',
-    dependencies: libfdt_dep
+    dependencies: libfdt_static_dep
   )
 
   lgen = generator(
@@ -92,7 +87,7 @@ if get_option('tools')
       ],
       dependencies: util_dep,
       install: true,
-      link_args: extra_link_args,
+      objects: libfdt_static_objs,
     )
   endif
 
@@ -113,11 +108,17 @@ if get_option('tools')
     ],
     dependencies: [util_dep, yaml],
     install: true,
-    link_args: extra_link_args,
+    objects: libfdt_static_objs,
   )
 
   foreach e: ['fdtdump', 'fdtget', 'fdtput', 'fdtoverlay']
-    dtc_tools += executable(e, files(e + '.c'), dependencies: util_dep, install: true, link_args: extra_link_args)
+    dtc_tools += executable(
+      e,
+      files(e + '.c'),
+      dependencies: util_dep,
+      install: true,
+      objects: libfdt_static_objs
+    )
   endforeach
 
   install_data(

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -104,14 +104,19 @@ if dl.found() and not static_build
   ]
 endif
 
-test_deps = [testutil_dep, util_dep, libfdt_dep]
+test_deps = [testutil_dep, util_dep]
 if not static_build
   test_deps += [dl]
 endif
 
 tests_exe = []
 foreach t: tests
-  tests_exe += executable(t, files(t + '.c'), dependencies: test_deps, link_args: extra_link_args)
+  tests_exe += executable(
+    t,
+    files(t + '.c'),
+    dependencies: test_deps,
+    objects: libfdt_static_objs,
+  )
 endforeach
 
 run_tests = find_program('run_tests.sh')


### PR DESCRIPTION
When using the meson-python backend to compile libfdt, it throws an installation error that it does not know where to install static libraries. We would disable the static libraries, but Meson is always building and installing both the shared and static libraries.

Right now we always build both shared and static libraries because our 'static-build' option needs us to link the dtc binaries against the static libfdt. So we need to make sure static is always built even if the build is configured for shared only.

So instead lets not link against the static library but link all of libfdt's objects directly. We will always have access to the library objects regardless if the build is configured for static or shared.