### PR TITLE
Pylibfdt fix python version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ include pylibfdt/libfdt.i
 include libfdt/libfdt.h
 include libfdt/fdt.h
 include libfdt/libfdt_env.h
+include VERSION.txt

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ class build_py(_build_py):
 
 setup(
     name='libfdt',
+    version=version,
     cmdclass = {'build_py' : build_py},
     author='Simon Glass',
     author_email='sjg@chromium.org',
@@ -72,5 +73,4 @@ setup(
         "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
         "Operating System :: OS Independent",
     ],
-
 )


### PR DESCRIPTION
> pylibfdt: fix Python version
>       
> In commit "pylibfdt: Remove some apparently deprecated options from
> setup.py" the scm version tracking was removed. But it was not replaced
> with the fixed version. This causes the Python modules to be installed
> as version '0.0.0'.
>       
> Signed-off-by: Brandon Maier <brandon.maier@collins.com>

> pylibfdt: add VERSION.txt to Python sdist
>       
> The VERSION.txt file tells setup.py what library version to use, so we
> must include it in the source distrbution.
>       
> Signed-off-by: Brandon Maier <brandon.maier@collins.com>
> 