### PR TITLE
checks: relax graph checks for overlays

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -1826,10 +1826,14 @@ static void check_graph_port(struct check *c, struct dt_info *dti,
 	if (node->bus != &graph_port_bus)
 		return;
 
+	check_graph_reg(c, dti, node);
+
+	/* skip checks below for overlays */
+	if (dti->dtsflags & DTSF_PLUGIN)
+		return;
+
 	if (!strprefixeq(node->name, node->basenamelen, "port"))
 		FAIL(c, dti, node, "graph port node name should be 'port'");
-
-	check_graph_reg(c, dti, node);
 }
 WARNING(graph_port, check_graph_port, NULL, &graph_nodes);
 
@@ -1864,10 +1868,14 @@ static void check_graph_endpoint(struct check *c, struct dt_info *dti,
 	if (!node->parent || node->parent->bus != &graph_port_bus)
 		return;
 
+	check_graph_reg(c, dti, node);
+
+	/* skip checks below for overlays */
+	if (dti->dtsflags & DTSF_PLUGIN)
+		return;
+
 	if (!strprefixeq(node->name, node->basenamelen, "endpoint"))
 		FAIL(c, dti, node, "graph endpoint node name should be 'endpoint'");
-
-	check_graph_reg(c, dti, node);
 
 	remote_node = get_remote_endpoint(c, dti, node);
 	if (!remote_node)


### PR DESCRIPTION
In device tree overlays, the following patterns occur frequently:
```
board.dts:
/dts-v1/;

/ {
	display-controller {
		ports {
			#address-cells = <1>;
			#size-cells = <0>;

			vp0: port@0 {
				reg = <0>;

				vp0_out: endpoint {
				};
			};

			vp1: port@1 {
				reg = <1>;
			};
		};
	};
};

overlay-endpoint.dtso:
/dts-v1/;
/plugin/;

&{/} {
	hdmi-tx-connector {
		port {
			hdmi_tx_in: endpoint {
				remote-endpoint = <&vp0_out>;
			};
		};
	};
};

&vp0_out {
	remote-endpoint = <&hdmi_tx_in>;
};
```

In this case, dtc expects that the node referenced by &vp0_out is named "endpoint", but the name cannot be inferred. Also, dtc complains about the connections between the endpoints not being bidirectional.

Similarly, for a different overlay overlay-port.dtso: 
```
/dts-v1/;
/plugin/;

&{/} {
	panel {
		port {
			panel_in: endpoint {
				remote-endpoint = <&vp1_out>;
			};
		};
	};
};

&vp1 {
	vp1_out: endpoint {
		remote-endpoint = <&panel_in>;
	};
};
```
dtc expects that the node referenced by &vp1 is named "port", but the name cannot be inferred.

Relax the corresponding checks and skip the parts that are not reasonable for device tree overlays.