### PR TITLE
allow using labels with fdtget/fdtput

### DIFF
--- a/libfdt/fdt_ro.c
+++ b/libfdt/fdt_ro.c
@@ -258,14 +258,18 @@ int fdt_path_offset_namelen(const void *fdt, const char *path, int namelen)
 	if (!can_assume(VALID_INPUT) && namelen <= 0)
 		return -FDT_ERR_BADPATH;
 
-	/* see if we have an alias */
+	/* see if we have an alias or symbol */
 	if (*path != '/') {
 		const char *q = memchr(path, '/', end - p);
 
 		if (!q)
 			q = end;
 
-		p = fdt_get_alias_namelen(fdt, p, q - p);
+		if (*p == '&')
+			p = fdt_get_symbol_namelen(fdt, p + 1, q - p - 1);
+		else
+			p = fdt_get_alias_namelen(fdt, p, q - p);
+
 		if (!p)
 			return -FDT_ERR_BADPATH;
 		offset = fdt_path_offset(fdt, p);

--- a/libfdt/libfdt.h
+++ b/libfdt/libfdt.h
@@ -570,9 +570,10 @@ int fdt_path_offset_namelen(const void *fdt, const char *path, int namelen);
  * address).
  *
  * If the path is not absolute (i.e. does not begin with '/'), the
- * first component is treated as an alias.  That is, the property by
- * that name is looked up in the /aliases node, and the value of that
- * property used in place of that first component.
+ * first component is treated as an alias (or, if it begins with '&',
+ * the rest is treated as a symbol).  That is, the property by that
+ * name is looked up in the /aliases (or /__symbols__) node, and the
+ * value of that property used in place of that first component.
  *
  * For example, for this small fragment
  *
@@ -592,12 +593,17 @@ int fdt_path_offset_namelen(const void *fdt, const char *path, int namelen);
  *
  *   /soc@0/i2c@30a40000/eeprom@52
  *   i2c2/eeprom@52
+ *   &foo/eeprom@52
+ *   &bar
+ *
+ * The latter two only work if the device tree blob has been compiled
+ * with the -@ dtc option.
  *
  * returns:
  *	structure block offset of the node with the requested path (>=0), on
  *		success
  *	-FDT_ERR_BADPATH, given path does not begin with '/' and the first
- *		component is not a valid alias
+ *		component is not a valid alias or symbol
  *	-FDT_ERR_NOTFOUND, if the requested node does not exist
  *	-FDT_ERR_BADMAGIC,
  *	-FDT_ERR_BADVERSION,

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -886,9 +886,10 @@ dtbs_equal_tests () {
 }
 
 fdtget_tests () {
+    at="$1"
     dts=label01.dts
     dtb=$dts.fdtget.test.dtb
-    run_dtc_test -O dtb -o $dtb "$SRCDIR/$dts"
+    run_dtc_test $at -O dtb -o $dtb "$SRCDIR/$dts"
 
     # run_fdtget_test <expected-result> [<flags>] <file> <node> <property>
     run_fdtget_test "MyBoardName" $dtb / model
@@ -907,6 +908,11 @@ fdtget_tests () {
     # Here the property size is not a multiple of 4 bytes, so it should fail
     run_wrap_error_test $DTGET -tlx $dtb /randomnode mixed
     run_fdtget_test "6162 6300 1234 0 a 0 b 0 c" -thx $dtb /randomnode mixed
+    if [ -n "$at" ]; then
+        run_fdtget_test "6162 6300 1234 0 a 0 b 0 c" -thx $dtb "&node" mixed
+    else
+        run_wrap_error_test $DTGET  -thx $dtb "&node" mixed
+    fi
     run_fdtget_test "61 62 63 0 12 34 0 0 0 a 0 0 0 b 0 0 0 c" \
 	-thhx $dtb /randomnode mixed
     run_wrap_error_test $DTGET -ts $dtb /randomnode doctor-who
@@ -922,12 +928,13 @@ fdtget_tests () {
 }
 
 fdtput_tests () {
+    at="$1"
     dts=label01.dts
     dtb=$dts.fdtput.test.dtb
     text="$SRCDIR/lorem.txt"
 
     # Allow just enough space for $text
-    run_dtc_test -O dtb -p $($STATSZ $text) -o $dtb "$SRCDIR/$dts"
+    run_dtc_test $at -O dtb -p $($STATSZ $text) -o $dtb "$SRCDIR/$dts"
 
     # run_fdtput_test <expected-result> <file> <node> <property> <flags> <value>
     run_fdtput_test "a_model" $dtb / model -ts "a_model"
@@ -941,12 +948,19 @@ fdtput_tests () {
     run_fdtput_test "a0b0c0d deeaae ef000000" $dtb /randomnode blob \
 	-tx "a0b0c0d deeaae ef000000"
     run_fdtput_test "$(cat $text)" $dtb /randomnode blob -ts "$(cat $text)"
+    if [ -n "$at" ]; then
+        run_fdtput_test "y" $dtb '&node' x -ts "y"
+        run_fdtput_test "z" $dtb '&node/child' x -ts "z"
+    else
+        run_wrap_error_test $DTPUT $dtb '&node' x -ts "y"
+        run_wrap_error_test $DTPUT $dtb '&node/child' x -ts "z"
+    fi
 
     # Test expansion of the blob when insufficient room for property
     run_fdtput_test "$(cat $text $text)" $dtb /randomnode blob -ts "$(cat $text $text)"
 
     # Start again with a fresh dtb
-    run_dtc_test -O dtb -p $($STATSZ $text) -o $dtb "$SRCDIR/$dts"
+    run_dtc_test $at -O dtb -p $($STATSZ $text) -o $dtb "$SRCDIR/$dts"
 
     # Node creation
     run_wrap_error_test $DTPUT $dtb -c /baldrick sod
@@ -974,7 +988,7 @@ fdtput_tests () {
     run_wrap_test $DTPUT $dtb -cp /chosen/son
 
     # Start again with a fresh dtb
-    run_dtc_test -O dtb -p $($STATSZ $text) -o $dtb "$SRCDIR/$dts"
+    run_dtc_test $at -O dtb -p $($STATSZ $text) -o $dtb "$SRCDIR/$dts"
 
     # Node delete
     run_wrap_test $DTPUT $dtb -c /chosen/node1 /chosen/node2 /chosen/node3
@@ -1152,10 +1166,12 @@ for set in $TESTSETS; do
 	    dtbs_equal_tests
 	    ;;
 	"fdtget")
-	    fdtget_tests
+	    fdtget_tests ""
+	    fdtget_tests "-@"
 	    ;;
 	"fdtput")
-	    fdtput_tests
+	    fdtput_tests ""
+	    fdtput_tests "-@"
 	    ;;
 	"fdtdump")
 	    fdtdump_tests


### PR DESCRIPTION
It can be convenient and more readable to use `&label` syntax with `fdtget` and `fdtput`, rather than having to know the full path. This small series adds that support by hooking into `fdt_path_offset_namelen()` in the same place where we already allow the first component to be an alias. Of course this only works for blobs that have been built with `-@`, but it shouldn't affect existing use cases.

[This is a re-opening of #89  which I managed to implicitly close in the process of rebasing the branch to current main.]