### PR TITLE
Restore phandles from binary representations

### DIFF
--- a/dtc.c
+++ b/dtc.c
@@ -343,6 +343,8 @@ int main(int argc, char *argv[])
 	if (generate_symbols)
 		generate_label_tree(dti, "__symbols__", true);
 
+	local_fixup_phandles(dti, "__local_fixups__");
+
 	if (generate_fixups) {
 		generate_fixups_tree(dti, "__fixups__");
 		generate_local_fixups_tree(dti, "__local_fixups__");

--- a/dtc.c
+++ b/dtc.c
@@ -343,6 +343,7 @@ int main(int argc, char *argv[])
 	if (generate_symbols)
 		generate_label_tree(dti, "__symbols__", true);
 
+	fixup_phandles(dti, "__fixups__");
 	local_fixup_phandles(dti, "__local_fixups__");
 
 	if (generate_fixups) {

--- a/dtc.c
+++ b/dtc.c
@@ -338,6 +338,8 @@ int main(int argc, char *argv[])
 	if (auto_label_aliases)
 		generate_label_tree(dti, "aliases", false);
 
+	generate_labels_from_tree(dti, "__symbols__");
+
 	if (generate_symbols)
 		generate_label_tree(dti, "__symbols__", true);
 

--- a/dtc.h
+++ b/dtc.h
@@ -342,6 +342,7 @@ void sort_tree(struct dt_info *dti);
 void generate_labels_from_tree(struct dt_info *dti, const char *name);
 void generate_label_tree(struct dt_info *dti, const char *name, bool allocph);
 void generate_fixups_tree(struct dt_info *dti, const char *name);
+void fixup_phandles(struct dt_info *dti, const char *name);
 void generate_local_fixups_tree(struct dt_info *dti, const char *name);
 void local_fixup_phandles(struct dt_info *dti, const char *name);
 
@@ -359,6 +360,8 @@ struct dt_info *dt_from_blob(const char *fname);
 
 /* Tree source */
 
+void property_add_marker(struct property *prop,
+			 enum markertype type, unsigned int offset, char *ref);
 void add_phandle_marker(struct dt_info *dti, struct property *prop, unsigned int offset);
 void dt_to_source(FILE *f, struct dt_info *dti);
 struct dt_info *dt_from_source(const char *f);

--- a/dtc.h
+++ b/dtc.h
@@ -343,6 +343,7 @@ void generate_labels_from_tree(struct dt_info *dti, const char *name);
 void generate_label_tree(struct dt_info *dti, const char *name, bool allocph);
 void generate_fixups_tree(struct dt_info *dti, const char *name);
 void generate_local_fixups_tree(struct dt_info *dti, const char *name);
+void local_fixup_phandles(struct dt_info *dti, const char *name);
 
 /* Checks */
 
@@ -358,6 +359,7 @@ struct dt_info *dt_from_blob(const char *fname);
 
 /* Tree source */
 
+void add_phandle_marker(struct dt_info *dti, struct property *prop, unsigned int offset);
 void dt_to_source(FILE *f, struct dt_info *dti);
 struct dt_info *dt_from_source(const char *f);
 

--- a/dtc.h
+++ b/dtc.h
@@ -339,6 +339,7 @@ struct dt_info *build_dt_info(unsigned int dtsflags,
 			      struct reserve_info *reservelist,
 			      struct node *tree, uint32_t boot_cpuid_phys);
 void sort_tree(struct dt_info *dti);
+void generate_labels_from_tree(struct dt_info *dti, const char *name);
 void generate_label_tree(struct dt_info *dti, const char *name, bool allocph);
 void generate_fixups_tree(struct dt_info *dti, const char *name);
 void generate_local_fixups_tree(struct dt_info *dti, const char *name);

--- a/flattree.c
+++ b/flattree.c
@@ -807,6 +807,7 @@ struct dt_info *dt_from_blob(const char *fname)
 	struct node *tree;
 	uint32_t val;
 	int flags = 0;
+	unsigned int dtsflags = DTSF_V1;
 
 	f = srcfile_relative_open(fname, NULL);
 
@@ -919,5 +920,8 @@ struct dt_info *dt_from_blob(const char *fname)
 
 	fclose(f);
 
-	return build_dt_info(DTSF_V1, reservelist, tree, boot_cpuid_phys);
+	if (get_subnode(tree, "__fixups__") || get_subnode(tree, "__local_fixups__"))
+		dtsflags |= DTSF_PLUGIN;
+
+	return build_dt_info(dtsflags, reservelist, tree, boot_cpuid_phys);
 }

--- a/livetree.c
+++ b/livetree.c
@@ -1046,6 +1046,27 @@ static void generate_local_fixups_tree_internal(struct dt_info *dti,
 		generate_local_fixups_tree_internal(dti, lfn, c);
 }
 
+void generate_labels_from_tree(struct dt_info *dti, const char *name)
+{
+	struct node *an;
+	struct property *p;
+
+	an = get_subnode(dti->dt, name);
+	if (!an)
+		return;
+
+	for_each_property(an, p) {
+		struct node *labeled_node;
+
+		labeled_node = get_node_by_path(dti->dt, p->val.val);
+		if (labeled_node)
+			add_label(&labeled_node->labels, p->name);
+		else if (quiet < 1)
+			fprintf(stderr, "Warning: Path %s referenced in property %s/%s missing",
+				p->val.val, name, p->name);
+	}
+}
+
 void generate_label_tree(struct dt_info *dti, const char *name, bool allocph)
 {
 	if (!any_label_tree(dti, dti->dt))

--- a/tests/over-determined.dts
+++ b/tests/over-determined.dts
@@ -1,0 +1,23 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	labelfornodea: nodea {
+		property = <&labelfornodea>;
+	};
+
+	nodeb {
+		property = <&nonexisting>;
+	};
+
+	__fixups__ {
+		nonexisting = "/nodeb:property:0";
+	};
+
+	__local_fixups__ {
+		nodea {
+			property = <0>;
+		};
+	};
+};
+

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -570,6 +570,10 @@ dtc_tests () {
     run_dtc_test -I dts -O dtb -o dtc_sized_cells.test.dtb "$SRCDIR/sized_cells.dts"
     run_test sized_cells dtc_sized_cells.test.dtb
 
+    run_dtc_test -I dts -O dts -o over-determined-once.test.dts "$SRCDIR/over-determined.dts"
+    run_dtc_test -I dts -O dts -o over-determined-twice.test.dts "over-determined-once.test.dts"
+    run_wrap_test cmp over-determined-once.test.dts over-determined-twice.test.dts
+
     run_dtc_test -I dts -O dtb -o dtc_extra-terminating-null.test.dtb "$SRCDIR/extra-terminating-null.dts"
     run_test extra-terminating-null dtc_extra-terminating-null.test.dtb
 

--- a/treesource.c
+++ b/treesource.c
@@ -347,7 +347,10 @@ void dt_to_source(FILE *f, struct dt_info *dti)
 {
 	struct reserve_info *re;
 
-	fprintf(f, "/dts-v1/;\n\n");
+	fprintf(f, "/dts-v1/;\n");
+	if (dti->dtsflags & DTSF_PLUGIN)
+		fprintf(f, "/plugin/;\n");
+	fprintf(f, "\n");
 
 	for (re = dti->reservelist; re; re = re->next) {
 		struct label *l;

--- a/treesource.c
+++ b/treesource.c
@@ -183,6 +183,39 @@ static void add_string_markers(struct property *prop, unsigned int offset, int l
 		mi = add_marker(mi, TYPE_STRING, offset + l, NULL);
 }
 
+void add_phandle_marker(struct dt_info *dti, struct property *prop, unsigned int offset)
+{
+	cell_t phandle;
+	struct node *refn;
+	char *ref;
+
+	if (prop->val.len < offset + 4) {
+		if (quiet < 1)
+			fprintf(stderr,
+				"Warning: property %s too short to contain a phandle at offset %u\n",
+				prop->name, offset);
+
+	}
+
+	phandle = dtb_ld32(prop->val.val + offset);
+	refn = get_node_by_phandle(dti->dt, phandle);
+
+	if (!refn) {
+		if (quiet < 1)
+			fprintf(stderr,
+				"Warning: node referenced by phandle 0x%x in property %s not found\n",
+				phandle, prop->name);
+		return;
+	}
+
+	if (refn->labels)
+		ref = refn->labels->label;
+	else
+		ref = refn->fullpath;
+
+	add_marker(&prop->val.markers, REF_PHANDLE, offset, ref);
+}
+
 static enum markertype guess_value_type(struct property *prop, unsigned int offset, int len)
 {
 	const char *p = prop->val.val + offset;

--- a/treesource.c
+++ b/treesource.c
@@ -173,23 +173,20 @@ static struct marker **add_marker(struct marker **mi,
 	return &nm->next;
 }
 
-static void add_string_markers(struct property *prop)
+static void add_string_markers(struct property *prop, unsigned int offset, int len)
 {
-	int l, len = prop->val.len;
-	const char *p = prop->val.val;
+	int l;
+	const char *p = prop->val.val + offset;
 	struct marker **mi = &prop->val.markers;
 
 	for (l = strlen(p) + 1; l < len; l += strlen(p + l) + 1)
-		mi = add_marker(mi, TYPE_STRING, l, NULL);
+		mi = add_marker(mi, TYPE_STRING, offset + l, NULL);
 }
 
-static enum markertype guess_value_type(struct property *prop)
+static enum markertype guess_value_type(struct property *prop, unsigned int offset, int len)
 {
-	int len = prop->val.len;
-	const char *p = prop->val.val;
-	struct marker *m = prop->val.markers;
+	const char *p = prop->val.val + offset;
 	int nnotstring = 0, nnul = 0;
-	int nnotstringlbl = 0, nnotcelllbl = 0;
 	int i;
 
 	for (i = 0; i < len; i++) {
@@ -199,30 +196,49 @@ static enum markertype guess_value_type(struct property *prop)
 			nnul++;
 	}
 
-	for_each_marker_of_type(m, LABEL) {
-		if ((m->offset > 0) && (prop->val.val[m->offset - 1] != '\0'))
-			nnotstringlbl++;
-		if ((m->offset % sizeof(cell_t)) != 0)
-			nnotcelllbl++;
-	}
-
-	if ((p[len-1] == '\0') && (nnotstring == 0) && (nnul <= (len-nnul))
-	    && (nnotstringlbl == 0)) {
+	if ((p[len-1] == '\0') && (nnotstring == 0) && (nnul <= len - nnul)) {
 		if (nnul > 1)
-			add_string_markers(prop);
+			add_string_markers(prop, offset, len);
 		return TYPE_STRING;
-	} else if (((len % sizeof(cell_t)) == 0) && (nnotcelllbl == 0)) {
+	} else if ((len % sizeof(cell_t)) == 0) {
 		return TYPE_UINT32;
 	}
 
 	return TYPE_UINT8;
 }
 
+static void guess_type_markers(struct property *prop)
+{
+	struct marker **m = &prop->val.markers;
+	unsigned int offset = 0;
+
+	for (m = &prop->val.markers; *m; m = &((*m)->next)) {
+		if (is_type_marker((*m)->type))
+			/* assume the whole property is already marked */
+			return;
+
+		if ((*m)->offset > offset) {
+			m = add_marker(m, guess_value_type(prop, offset, (*m)->offset - offset),
+				       offset, NULL);
+
+			offset = (*m)->offset;
+		}
+
+		if ((*m)->type == REF_PHANDLE) {
+			m = add_marker(m, TYPE_UINT32, offset, NULL);
+			offset += 4;
+		}
+	}
+
+	if (offset < prop->val.len)
+		add_marker(m, guess_value_type(prop, offset, prop->val.len - offset),
+			   offset, NULL);
+}
+
 static void write_propval(FILE *f, struct property *prop)
 {
 	size_t len = prop->val.len;
-	struct marker *m = prop->val.markers;
-	struct marker dummy_marker;
+	struct marker *m;
 	enum markertype emit_type = TYPE_NONE;
 	char *srcstr;
 
@@ -241,14 +257,8 @@ static void write_propval(FILE *f, struct property *prop)
 
 	fprintf(f, " =");
 
-	if (!next_type_marker(m)) {
-		/* data type information missing, need to guess */
-		dummy_marker.type = guess_value_type(prop);
-		dummy_marker.next = prop->val.markers;
-		dummy_marker.offset = 0;
-		dummy_marker.ref = NULL;
-		m = &dummy_marker;
-	}
+	guess_type_markers(prop);
+	m = prop->val.markers;
 
 	for_each_marker(m) {
 		size_t chunk_len = (m->next ? m->next->offset : len) - m->offset;

--- a/treesource.c
+++ b/treesource.c
@@ -173,6 +173,12 @@ static struct marker **add_marker(struct marker **mi,
 	return &nm->next;
 }
 
+void property_add_marker(struct property *prop,
+			 enum markertype type, unsigned int offset, char *ref)
+{
+	add_marker(&prop->val.markers, type, offset, ref);
+}
+
 static void add_string_markers(struct property *prop, unsigned int offset, int len)
 {
 	int l;


### PR DESCRIPTION
device trees generated with options `-@` and `-L` contain information about the label names used originally and which values are phandle values. This information can be reused when compiling back to dts format to make the result much more human readable.

Also dtdiff is adapted to make use of this to generate smaller diffs without hunks e.g. for a different phandle allocation.

This superseeds pull request https://github.com/dgibson/dtc/pull/93.