### PR TITLE
pylibfdt/libfdt.i: Use SWIG_AppendOutput

### DIFF
--- a/pylibfdt/libfdt.i
+++ b/pylibfdt/libfdt.i
@@ -1137,7 +1137,7 @@ typedef uint32_t fdt32_t;
 			fdt_string(fdt1, fdt32_to_cpu($1->nameoff)));
 		buff = PyByteArray_FromStringAndSize(
 			(const char *)($1 + 1), fdt32_to_cpu($1->len));
-		resultobj = SWIG_Python_AppendOutput(resultobj, buff);
+		resultobj = SWIG_AppendOutput(resultobj, buff);
 	}
 }
 
@@ -1178,7 +1178,7 @@ typedef uint32_t fdt32_t;
 
 %typemap(argout) int *depth {
         PyObject *val = Py_BuildValue("i", *arg$argnum);
-        resultobj = SWIG_Python_AppendOutput(resultobj, val);
+        resultobj = SWIG_AppendOutput(resultobj, val);
 }
 
 %apply int *depth { int *depth };
@@ -1190,7 +1190,7 @@ typedef uint32_t fdt32_t;
 
 %typemap(argout) uint64_t * {
         PyObject *val = PyLong_FromUnsignedLongLong(*arg$argnum);
-        resultobj = SWIG_Python_AppendOutput(resultobj, val);
+        resultobj = SWIG_AppendOutput(resultobj, val);
 }
 
 %include "cstring.i"


### PR DESCRIPTION
Swig has changed language specific AppendOutput functions. The helper macro SWIG_AppendOutput remains unchanged. Use that instead of SWIG_Python_AppendOutput, which would require an extra parameter since swig 4.3.0.

| /home/flk/poky/build-hypr/tmp/work/x86_64-linux/python3-dtc-native/1.7.0/git/pylibfdt/libfdt_wrap.c: In function ‘_wrap_fdt_next_node’: | /home/flk/poky/build-hypr/tmp/work/x86_64-linux/python3-dtc-native/1.7.0/git/pylibfdt/libfdt_wrap.c:5598:17: error: too few arguments to function ‘SWIG_Python_AppendOutput’
|  5598 |     resultobj = SWIG_Python_AppendOutput(resultobj, val);