### PR TITLE
Add a SBOM file in CycloneDX format

### DIFF
--- a/libfdt/sbom.cdx.json
+++ b/libfdt/sbom.cdx.json
@@ -1,0 +1,41 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:github/dgibson/libfdt@@VCS_TAG@",
+      "cpe": "cpe:2.3:a:dgibson:libfdt:@VCS_TAG@:*:*:*:*:*:*:*",
+      "name": "libfdt",
+      "version": "@VCS_VERSION@",
+      "description": "Utility library for reading and manipulating the FDT binary format",
+      "authors": [
+        {
+          "name": "@VCS_SBOM_AUTHORS@"
+        }
+      ],
+      "supplier": {
+        "name": "libfdt developers"
+      },
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause"
+          }
+        },
+        {
+          "license": {
+            "id": "GPL-2.0-or-later"
+          }
+        }
+      ],
+      "externalReferences": [
+        {
+          "type": "vcs",
+          "url": "https://github.com/dgibson/dtc"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hi,

My name is Richard Hughes and I'm a developer at Red Hat. I'm the maintainer of fwupd and LVFS, and am trying to improve software supply chain security by encouraging OEMs, ODMs and IBVs to ship Software Bill of Materials with each firmware binary blob (SBOMs).

I'm working alongside lots of other companies proactively trying to do the right thing. The reason I've opened this pull request is because libfdt is either used in the *build process* of a firmware we care about (e.g. EDK II, or coreboot) or is built *into the firmware binary* itself. Although my personal focus is on firmware, the SBOM file is in CycloneDX format (one of the most popular industry standards) which makes it also useful when building containers or OS images too.

I would like to contribute this template SBOM file into your project that gets included into source control with substituted values that get populated automatically. I'm not super familiar with libfdt, and so I've done my best populating the project values -- but please point out any that are incorrect and I'll fix them up. I've also put the `sbom.cdx.json` file in what I feel is the right place, but please say if you want me to put it somewhere different or name it a different thing; the directory and `sbom` prefix are unimportant.

I've written a bit more about this proposal here https://blogs.gnome.org/hughsie/2024/11/14/firmware-sboms-for-open-source-projects/ and there's also lot more information about firmware SBOMs here: https://lvfs.readthedocs.io/en/latest/sbom.html – many thanks for your time.

Richard
