### PR TITLE
tests/sw_tree1.c: fix unitialized saveptr

### DIFF
--- a/tests/sw_tree1.c
+++ b/tests/sw_tree1.c
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
 		}
 	}
 	if (argc == 3) {
-		char *str = argv[2], *saveptr, *tok;
+		char *str = argv[2], *saveptr = NULL, *tok;
 		bool default_flag = false;
 
 		while ((tok = strtok_r(str, ",", &saveptr)) != NULL) {


### PR DESCRIPTION
Building the dtc tests on the Conda build system results in the following error.

> In function '__strtok_r_1c',                                                                                                                                     2024-11-23T19:17:20.7930512Z     inlined from 'main' at ../tests/sw_tree1.c:140:17:
> $BUILD_PREFIX/x86_64-conda-linux-gnu/sysroot/usr/include/bits/string2.h:1177:10: error: 'saveptr' may be used uninitialized [-Werror=maybe-uninitialized]
>  1177 |   while (*__s == __sep)
>       |          ^~~~
> ../tests/sw_tree1.c: In function 'main':
> ../tests/sw_tree1.c:137:39: note: 'saveptr' was declared here
>   137 |                 char *str = argv[2], *saveptr, *tok;
>       |                                       ^~~~~~~
> cc1: all warnings being treated as errors

The manpage `strtok(3)` says the following.

> VERSIONS
>   On some implementations, *saveptr is required to be NULL on the first call to strtok_r() that is being used to parse str.

So set it to NULL.