### PR TITLE
.github/workflows: update ubuntu runner to supported version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          os: [ "alpine", "archlinux", "fedora", "ubuntu:23.10" ]
+          os: [ "alpine", "archlinux", "fedora", "ubuntu" ]
 
     container:
       image: ${{ matrix.os }}
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          os: [ "alpine", "archlinux", "fedora", "ubuntu:23.10" ]
+          os: [ "alpine", "archlinux", "fedora", "ubuntu" ]
 
     container:
       image: ${{ matrix.os }}


### PR DESCRIPTION
The Ubuntu runner fails with the following message

> E: The repository 'http://security.ubuntu.com/ubuntu mantic-security Release' does not have a Release file.

Ubuntu 23.10 is end-of-life as of July 2024 anyway. So switch to the latest Ubuntu tag, which is currently 24.04.

See https://discourse.ubuntu.com/t/edubuntu-23-10-has-reached-end-of-life-eol/46325