### PR TITLE
fdtput: Fix documentation about existing nodes

### DIFF
--- a/fdtput.c
+++ b/fdtput.c
@@ -389,8 +389,8 @@ static struct option const usage_long_opts[] = {
 	USAGE_COMMON_LONG_OPTS,
 };
 static const char * const usage_opts_help[] = {
-	"Create nodes if they don't already exist",
-	"Delete nodes (and any subnodes) if they already exist",
+	"Create nodes",
+	"Delete nodes (and any subnodes)",
 	"Delete properties if they already exist",
 	"Automatically create nodes as needed for the node path",
 	"Type of data",


### PR DESCRIPTION
The documentation claims that `-c` would "Create nodes if they don't already exist". This is true, but suggests that trying to create a node that already exists is not an error. fdtput however errors out in that case. Similar `fdtput -d` errors out when called for a non-existing node.

Drop the "if they [don't] already exist" to make that clearer.