### PR TITLE
dtdiff: Use input format dtb for dtbo files

### DIFF
--- a/dtdiff
+++ b/dtdiff
@@ -17,7 +17,7 @@ source_and_sort () {
 	    *.dts)
 		IFORMAT=dts
 		;;
-	    *.dtb)
+	    *.dtb|*.dtbo)
 		IFORMAT=dtb
 		;;
 	esac


### PR DESCRIPTION
The file ending .dtbo is typically used for device tree overlays. These are in the dtb input format, too. So assume this input format for *.dtbo as is already done for *.dtb.

This is currently also included in #151, but when updating this PR I will drop it from there as it's unrelated to it.