### PR TITLE
Add informative error for stray identifier

### DIFF
--- a/dtc-lexer.l
+++ b/dtc-lexer.l
@@ -151,6 +151,19 @@ static void PRINTF(1, 2) lexical_error(const char *fmt, ...);
 			return DT_LABEL;
 		}
 
+<V1>{LABEL} 	{
+			/* Missed includes or macro definitions while
+			 * preprocessing can lead to unexpected identifiers in
+			 * the input. Report a slightly more informative error
+			 * in this case */
+
+			lexical_error("Unexpected '%s'", yytext);
+
+			/* Guess that it was supposed to be a macro that expands
+			 * to a literal for purposes of further processing */
+			return DT_LITERAL;
+		}
+
 <V1>([0-9]+|0[xX][0-9a-fA-F]+)(U|L|UL|LL|ULL)? {
 			char *e;
 			DPRINT("Integer Literal: '%s'\n", yytext);


### PR DESCRIPTION
When a DTS is preprocessed, sometimes the user fails to include the
correct header files, or make a spelling mistake on a macro name. This
leads to a stray identifier in the DTS, like:

```
property = <1 2 FOO BAR(3, 4)>;
```

Give a more helpful error message than "syntax error" by recognizing and
reporting the identifier, like this:

```
Lexical error: <stdin>:2.21-24 Unexpected 'FOO'
```

Also, guess that such an identifier expands to a literal, in the hopes
that it will be helpful for further processing.

Signed-off-by: Vivian Wang <wangruikang@iscas.ac.cn>
