### PR TITLE
libfdt: Remove old MacOS strnlen workaround

### DIFF
--- a/libfdt/libfdt_env.h
+++ b/libfdt/libfdt_env.h
@@ -66,31 +66,4 @@ static inline fdt64_t cpu_to_fdt64(uint64_t x)
 #undef CPU_TO_FDT16
 #undef EXTRACT_BYTE
 
-#ifdef __APPLE__
-#include <AvailabilityMacros.h>
-
-/* strnlen() is not available on Mac OS < 10.7 */
-# if !defined(MAC_OS_X_VERSION_10_7) || (MAC_OS_X_VERSION_MAX_ALLOWED < \
-                                         MAC_OS_X_VERSION_10_7)
-
-#define strnlen fdt_strnlen
-
-/*
- * fdt_strnlen: returns the length of a string or max_count - which ever is
- * smallest.
- * Input 1 string: the string whose size is to be determined
- * Input 2 max_count: the maximum value returned by this function
- * Output: length of the string or max_count (the smallest of the two)
- */
-static inline size_t fdt_strnlen(const char *string, size_t max_count)
-{
-    const char *p = memchr(string, 0, max_count);
-    return p ? p - string : max_count;
-}
-
-#endif /* !defined(MAC_OS_X_VERSION_10_7) || (MAC_OS_X_VERSION_MAX_ALLOWED <
-          MAC_OS_X_VERSION_10_7) */
-
-#endif /* __APPLE__ */
-
 #endif /* LIBFDT_ENV_H */


### PR DESCRIPTION
The check for the MacOS X version (10.7) is problematic, because it fails unless _DARWIN_C_SOURCE is defined if also _POSIX_C_SOURCE or _XOPEN_SOURCE is defined, as then the Darwin version defines are not defined.  We cannot force _DARWIN_C_SOURCE reliably in the header either, because we cannot be sure that the libfdt_env.h has not already been included by another source before.

The check is also only for very old versions of Mac OS X. In the interest of not replacing strnlen arbitrarily for sources using libfdt and considering that the last version of OS X 10.6 was released in 2011 I propose to remove the workaround for that system.

We noticed as compiling fdt_strnlen in C++ environments fails (missing cast for memchr).