### PR TITLE
Fix discarded const qualifiers

### DIFF
--- a/fdtput.c
+++ b/fdtput.c
@@ -254,19 +254,21 @@ static int create_paths(char **blob, const char *in_path)
 static int create_node(char **blob, const char *node_name)
 {
 	int node = 0;
-	char *p;
+	const char *p;
+	char *path = NULL;
 
 	p = strrchr(node_name, '/');
 	if (!p) {
 		report_error(node_name, -1, -FDT_ERR_BADPATH);
 		return -1;
 	}
-	*p = '\0';
 
 	*blob = realloc_node(*blob, p + 1);
 
 	if (p > node_name) {
-		node = fdt_path_offset(*blob, node_name);
+		path = xstrndup(node_name, (size_t)(p - node_name));
+		node = fdt_path_offset(*blob, path);
+		free(path);
 		if (node < 0) {
 			report_error(node_name, -1, node);
 			return -1;

--- a/libfdt/fdt_overlay.c
+++ b/libfdt/fdt_overlay.c
@@ -407,7 +407,8 @@ static int overlay_fixup_phandle(void *fdt, void *fdto, int symbols_off,
 		const char *fixup_str = value;
 		uint32_t path_len, name_len;
 		uint32_t fixup_len;
-		char *sep, *endptr;
+		const char *sep;
+		char *endptr;
 		int poffset, ret;
 
 		fixup_end = memchr(value, '\0', len);

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@ add_project_arguments(
     '-Wshadow',
     '-Wsuggest-attribute=format',
     '-Wwrite-strings',
+    '-Wdiscarded-qualifiers',
   ]),
   language: 'c'
 )


### PR DESCRIPTION
It's unsafe to implicitly discard the const qualifier on a pointer. In overlay_fixup_phandle(), this was probably just an oversight, and making the "sep" variable a const char * is sufficient to fix it.

In create_node(), however, the "p" variable is directly modifying the buffer pointed to by "const char* node_name". To fix this, we need to actually make a duplicate of the buffer and operate on that instead.

This introduces a malloc()/free()  and an unbounded strdup() into the operation, but fdtput isn't a long-running service and the node_name argument comes directly from argv, so this shouldn't introduce a significant performance impact.