### PR TITLE
Added empty node name check

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -340,6 +340,14 @@ static void check_node_name_format(struct check *c, struct dt_info *dti,
 }
 ERROR(node_name_format, check_node_name_format, NULL, &node_name_chars);
 
+static void check_node_name_not_empty(struct check *c, struct dt_info *dti,
+				      struct node *node)
+{
+	if (node->basenamelen == 0 && node->parent != NULL)
+		FAIL(c, dti, node, "Empty node name");
+}
+ERROR(node_name_not_empty, check_node_name_not_empty, NULL, &node_name_chars);
+
 static void check_node_name_vs_property_name(struct check *c,
 					     struct dt_info *dti,
 					     struct node *node)
@@ -1899,7 +1907,7 @@ WARNING(graph_endpoint, check_graph_endpoint, NULL, &graph_nodes);
 
 static struct check *check_table[] = {
 	&duplicate_node_names, &duplicate_property_names,
-	&node_name_chars, &node_name_format, &property_name_chars,
+	&node_name_chars, &node_name_format, &node_name_not_empty, &property_name_chars,
 	&name_is_string, &name_properties, &node_name_vs_property_name,
 
 	&duplicate_label,


### PR DESCRIPTION
The Devicetree specification states:

```
Each node in the devicetree is named according to the following convention:
node-name@unit-address
The node-name component specifies the name of the node. It shall be 1 to 31 characters in length and consist solely of
characters from the set of characters in Table 2.1.
```
If I understand correctly the parser/lexer configuration, `dtc` considers a node name as a non-empty sequences of the allowed characters **plus** the `@` character; `unit-address` extraction is processed after parsing.
This has the side effect of considering an empty name plus an address as a valid node name, e.g.:

```dts
/dts-v1/; 

/ {
    @0 {
    };
};
```
Does not throw any errors.

I've added the `node_name_not_empty` check, verifying that the `node->basenamelen` is not zero (unless it's the root node).