### PR TITLE
checks: Add missing phandle_references prereq to interrupts_property

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -1769,7 +1769,7 @@ static void check_interrupts_property(struct check *c,
 			  irq_prop->val.len, (int)(irq_cells * sizeof(cell_t)));
 	}
 }
-WARNING(interrupts_property, check_interrupts_property, &phandle_references);
+WARNING(interrupts_property, check_interrupts_property, NULL, &phandle_references);
 
 static const struct bus_type graph_port_bus = {
 	.name = "graph-port",


### PR DESCRIPTION
The WARNING macro signature is (name, fn, data, ...prereqs), but interrupts_property was registered with &phandle_references in the data slot instead of as a prereq.  Since c->data is const void *, the misuse compiled silently and the check has been running with num_prereqs == 0.

The bug is normally masked: many other checks (interrupt_map, gpios_property, omit_unused_nodes, and the *_property checks generated by WARNING_PROPERTY_PHANDLE_CELLS) correctly list phandle_references as a prereq, and run_check recurses into prereqs unconditionally.  As long as any one of them is enabled, fixup_phandle_references is pulled in transitively and the parser's 0xffffffff placeholder is replaced with the real phandle before check_interrupts_property reads it.

The bug becomes visible when every other consumer of phandle_references is silenced (-Eno-phandle_references plus -Wno- for the *_property, gpios_property and interrupt_map checks).  In that case the placeholder remains and interrupts_property falsely reports "Invalid phandle" / "Missing interrupt-parent" on a valid tree.  Reordering check_table[] could also expose it under default flags.

Add the missing NULL so &phandle_references lands in the prereq slot.