### PR TITLE
libfdt: fix UBSAN null pointer in fdt_property()

### DIFF
--- a/libfdt/fdt_sw.c
+++ b/libfdt/fdt_sw.c
@@ -330,7 +330,8 @@ int fdt_property(void *fdt, const char *name, const void *val, int len)
 	ret = fdt_property_placeholder(fdt, name, len, &ptr);
 	if (ret)
 		return ret;
-	memcpy(ptr, val, len);
+	if (len)
+		memcpy(ptr, val, len);
 	return 0;
 }
 


### PR DESCRIPTION
fdt_property() unconditionally calls memcpy(ptr, val, len) even when len is zero and val is NULL.  This is a legitimate calling convention for adding empty FDT properties such as "interrupt-controller", which carry no payload.

However, compilers that treat memcpy as nonnull on its pointer arguments will fire UBSAN before observing that len is zero.

Guard the memcpy() with a check on len so it is skipped entirely when there is no payload to copy, bringing the code in line with the nonnull contract.