### PR TITLE
Set default permissions for workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ name: Build test
   pull_request:
     branches:
       - main
+permissions:
+  contents: read
 
 # ensure that the workflow is only triggered once per PR,  subsequent pushes to the PR will cancel
 # and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency


### PR DESCRIPTION
Old github repositories created before 2023 run jobs with a GITHUB_TOKEN
that has write permissions by default for PRs from inside the repo (not
a fork), unless set otherwise in the repository.[0][1]

[0] https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/
[1] https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/

Set it explicitly so there won't be a chance that a compromise of an action
will be able to modify anything in the repository.

Pointed out by zizmor[2]
[2] https://github.com/zizmorcore/zizmor