### PR TITLE
livetree: Fix a comparison of integers with different signedness

### DIFF
--- a/livetree.c
+++ b/livetree.c
@@ -1234,7 +1234,7 @@ void fixup_phandles(struct dt_info *dti, const char *name)
 				continue;
 
 			offset = strtol(soffset, NULL, 0);
-			if (offset < 0 || offset + 4 > p->val.len) {
+			if (offset < 0 || (unsigned int)offset + 4 > p->val.len) {
 				if (quiet < 1)
 					fprintf(stderr,
 						"Warning: Label %s contains invalid offset for property %s in node %s\n",


### PR DESCRIPTION
On some architectures we have:

	livetree.c: In function 'fixup_phandles':
	livetree.c:1237:54: error: comparison of integer expressions of different signedness: 'long int' and 'unsigned int' [-Werror=sign-compare]
	 1237 |                         if (offset < 0 || offset + 4 > p->val.len) {
	      |                                                      ^
	cc1: all warnings being treated as errors
	make: *** [Makefile:307: livetree.o] Error 1

Fixes: a26ef6400bd8 ("Restore phandle references from __fixups__ node")
Closes: https://github.com/dgibson/dtc/issues/186