### PR TITLE
pylibfdt: Grow the FdtSw buffer geometrically

### DIFF
--- a/pylibfdt/libfdt.i
+++ b/pylibfdt/libfdt.i
@@ -857,7 +857,7 @@ class FdtSw(FdtRo):
     device tree. This will be increased automatically as needed as new items
     are added to the tree.
     """
-    INC_SIZE = 1024  # Expand size by this much when out of space
+    INC_SIZE = 1024  # Expand size by at least this much when out of space
 
     def __init__(self, size_hint=None):
         """Create a new FdtSw object
@@ -901,6 +901,10 @@ class FdtSw(FdtRo):
         -NOSPACE then the FDT will be expanded to have more space, and True will
         be returned, indicating that the operation needs to be tried again.
 
+        Each expansion copies the whole tree into a new buffer, so the size is
+        at least doubled rather than grown by a fixed amount, to keep the total
+        amount of copying proportional to the size of the tree.
+
         Args:
             val: Return value from the operation that was attempted
 
@@ -908,7 +912,7 @@ class FdtSw(FdtRo):
             True if the operation must be retried, else False
         """
         if check_err(val, QUIET_NOSPACE) < 0:
-            self.resize(len(self._fdt) + self.INC_SIZE)
+            self.resize(len(self._fdt) + max(len(self._fdt), self.INC_SIZE))
             return True
         return False
 


### PR DESCRIPTION
Every expansion copies the whole tree into a freshly allocated buffer, so growing by a fixed amount makes building a tree cost time quadratic in its size. This is especially painful when assembling larger images with the data inline, such as U-Boot's binman does for FIT images.

Grow by at least as much as the tree already holds, which is what variable sized arrays usually do specifically to avoid such excessive copying.

With this change, building a Rockchip TF-A+Falcon image whose FIT carries a 31 MiB kernel takes 33.1 s rather than 44.4 s, with binman itself down from 25.3 s to 14.0 s, as 7139 reallocations become 187. The images produced are byte-identical.