### PR TITLE
pylibfdt: expose address cells, size cells and memory reservation add/delete accessors

### DIFF
--- a/pylibfdt/libfdt.i
+++ b/pylibfdt/libfdt.i
@@ -302,6 +302,38 @@ class FdtRo(object):
         check_err(val[0], quiet)
         return val[1:]
 
+    def address_cells(self, nodeoffset, quiet=()):
+        """Return the number of address cells used by a node's children
+
+        Args:
+            nodeoffset: Offset of the node to check
+            quiet: Errors to ignore (empty to raise on all errors)
+
+        Returns:
+            Number of address cells used by the children of @nodeoffset
+
+        Raises:
+            FdtException if the node has an invalid #address-cells property,
+            or another error occurs
+        """
+        return check_err(fdt_address_cells(self._fdt, nodeoffset), quiet)
+
+    def size_cells(self, nodeoffset, quiet=()):
+        """Return the number of size cells used by a node's children
+
+        Args:
+            nodeoffset: Offset of the node to check
+            quiet: Errors to ignore (empty to raise on all errors)
+
+        Returns:
+            Number of size cells used by the children of @nodeoffset
+
+        Raises:
+            FdtException if the node has an invalid #size-cells property, or
+            another error occurs
+        """
+        return check_err(fdt_size_cells(self._fdt, nodeoffset), quiet)
+
     def subnode_offset(self, parentoffset, name, quiet=()):
         """Get the offset of a named subnode
 

--- a/pylibfdt/libfdt.i
+++ b/pylibfdt/libfdt.i
@@ -636,6 +636,42 @@ class Fdt(FdtRo):
         del self._fdt[self.totalsize():]
         return err
 
+    def add_mem_rsv(self, addr, size, quiet=()):
+        """Add a memory reserve-map record
+
+        This asks the client program not to use the given region of memory,
+        e.g. because something was loaded there.
+
+        Args:
+            addr: Start address of the region to reserve
+            size: Size of the region to reserve, in bytes
+            quiet: Errors to ignore (empty to raise on all errors)
+
+        Returns:
+            Error code, or 0 if OK
+
+        Raises:
+            FdtException if there is no space for another record, or another
+            error occurs
+        """
+        return check_err(fdt_add_mem_rsv(self._fdt, addr, size), quiet)
+
+    def del_mem_rsv(self, index, quiet=()):
+        """Remove the indexed memory reserve-map record
+
+        Args:
+            index: Record to remove (0=first)
+            quiet: Errors to ignore (empty to raise on all errors)
+
+        Returns:
+            Error code, or 0 if OK
+
+        Raises:
+            FdtException if there is no record at @index, or another error
+            occurs
+        """
+        return check_err(fdt_del_mem_rsv(self._fdt, index), quiet)
+
     def set_name(self, nodeoffset, name, quiet=()):
         """Set the name of a node
 

--- a/tests/pylibfdt_tests.py
+++ b/tests/pylibfdt_tests.py
@@ -411,6 +411,20 @@ class PyLibfdtBasicTests(unittest.TestCase):
                           self.fdt.get_mem_rsv(0))
         self.assertEqual([123456789, 0o10000], self.fdt.get_mem_rsv(1))
 
+    def testAddDelReserveMap(self):
+        """Test that we can add to and remove from the memory reserve map"""
+        fdt = _ReadFdt('test_tree1.dtb')
+        fdt.resize(fdt.totalsize() + 64)
+
+        self.assertEqual(0, fdt.add_mem_rsv(0x40000000, 0x2000))
+        self.assertEqual(3, fdt.num_mem_rsv())
+        self.assertEqual([0x40000000, 0x2000], fdt.get_mem_rsv(2))
+
+        self.assertEqual(0, fdt.del_mem_rsv(2))
+        self.assertEqual(2, fdt.num_mem_rsv())
+        self.assertEqual(-libfdt.NOTFOUND,
+                         fdt.del_mem_rsv(2, QUIET_NOTFOUND))
+
     def testCells(self):
         """Test that we can read #address-cells and #size-cells"""
         self.assertEqual(1, self.fdt.address_cells(0))

--- a/tests/pylibfdt_tests.py
+++ b/tests/pylibfdt_tests.py
@@ -411,6 +411,21 @@ class PyLibfdtBasicTests(unittest.TestCase):
                           self.fdt.get_mem_rsv(0))
         self.assertEqual([123456789, 0o10000], self.fdt.get_mem_rsv(1))
 
+    def testCells(self):
+        """Test that we can read #address-cells and #size-cells"""
+        self.assertEqual(1, self.fdt.address_cells(0))
+        self.assertEqual(0, self.fdt.size_cells(0))
+
+        # A node without the properties inherits neither, so the libfdt
+        # defaults of 2 and 1 apply
+        node = self.fdt.path_offset('/subnode@1')
+        self.assertEqual(2, self.fdt.address_cells(node))
+        self.assertEqual(1, self.fdt.size_cells(node))
+
+        node = self.fdt.path_offset('/subnode@2')
+        self.assertEqual(1, self.fdt.address_cells(node))
+        self.assertEqual(0, self.fdt.size_cells(node))
+
     def testEmpty(self):
         """Test that we can create an empty tree"""
         self.assertEqual(-libfdt.NOSPACE,


### PR DESCRIPTION
Currently the access to address-cells/size cells requires poking into the FdtRo._fdt private buffer. Similarly, adding or deleting memory reservations requires poking into the Fdt._fdt private buffer.

This complicates things such as inserting a /chosen node with a pre-set kernel command line and initrd location/size properties into an existing device tree (as is required for preparing a device tree blob for booting with no runtime patching by a bootloader, e.g. using U-Boot's Falcon mode), so add public accessors for these.