### PR TITLE
libfdt: avoid hosted headers for freestanding (EFI) consumers

### DIFF
--- a/libfdt/libfdt_env.h
+++ b/libfdt/libfdt_env.h
@@ -10,8 +10,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+/* Avoid hosted libc headers for EFI (freestanding) builds. */
+#if !defined(__STDC_HOSTED__) || __STDC_HOSTED__
 #include <stdlib.h>
 #include <string.h>
+#endif
 #include <limits.h>
 
 #ifdef __CHECKER__


### PR DESCRIPTION
We want to use libfdt in systemd's EFI binaries (stub and loader) to handle device trees. As EFI binaries are PE, this requires doing static "freestanding" builds.

libfdt_env.h includes stdlib.h and string.h unconditionally. This imports hosted libc declarations, whereas the EFI runtime provides its own declarations, and causes declaration conflicts.

Use the compiler-defined __STDC_HOSTED__ value to include these headers only for hosted consumers. Normal userspace builds retain their existing behavior, while freestanding EFI consumers need no bespoke builds and can just include the static library shipped by distros.