### PR TITLE
pylibfdt: Replace removed SWIG Python 2 compatibility macros

### DIFF
--- a/pylibfdt/libfdt.i
+++ b/pylibfdt/libfdt.i
@@ -1136,7 +1136,7 @@ typedef uint32_t fdt32_t;
 	PyObject *buff;
 
 	if ($1) {
-		resultobj = PyString_FromString(
+		resultobj = PyUnicode_FromString(
 			fdt_string(fdt1, fdt32_to_cpu($1->nameoff)));
 		buff = PyByteArray_FromStringAndSize(
 			(const char *)($1 + 1), fdt32_to_cpu($1->len));
@@ -1169,13 +1169,13 @@ typedef uint32_t fdt32_t;
         }
         $1 = PyBytes_AsString($input);
     %#else
-        $1 = PyString_AsString($input);   /* char *str */
+        $1 = PyBytes_AsString($input);   /* char *str */
     %#endif
 }
 
 /* typemaps used for fdt_next_node() */
 %typemap(in, numinputs=1) int *depth (int depth) {
-   depth = (int) PyInt_AsLong($input);
+   depth = (int) PyLong_AsLong($input);
    $1 = &depth;
 }
 


### PR DESCRIPTION
SWIG 4.5.0 removed Python 2 compatibility macros (PyInt_*, PyString_*) from its runtime header pyhead.swg (see commit 79f7a2b7cb7d). Replace them with their Python 3 C API equivalents:

- PyString_FromString -> PyUnicode_FromString
- PyString_AsString -> PyBytes_AsString
- PyInt_AsLong -> PyLong_AsLong

The replacements are safe since the macros were already aliased to these exact functions in SWIG's Python 3 code path.