### PR TITLE
fstree: Add output to directory functionality

### DIFF
--- a/dtc.c
+++ b/dtc.c
@@ -80,14 +80,15 @@ static const char * const usage_opts_help[] = {
 	 "\t\tdts - device tree source text\n"
 	 "\t\tdtb - device tree blob\n"
 	 "\t\tfs  - /proc/device-tree style directory",
-	"\n\tOutput file",
+	"\n\tOutput file or directory",
 	"\n\tOutput formats are:\n"
 	 "\t\tdts - device tree source text\n"
 	 "\t\tdtb - device tree blob\n"
 #ifndef NO_YAML
 	 "\t\tyaml - device tree encoded as YAML\n"
 #endif
-	 "\t\tasm - assembler source",
+	 "\t\tasm - assembler source\n"
+	 "\t\tfs  - /proc/device-tree style directory",
 	"\n\tBlob version to produce, defaults to "stringify(DEFAULT_FDT_VERSION)" (for dtb and asm output)",
 	"\n\tOutput dependency file",
 	"\n\tMake space for <number> reserve map entries (for dtb and asm output)",
@@ -354,7 +355,9 @@ int main(int argc, char *argv[])
 	if (sort)
 		sort_tree(dti);
 
-	if (streq(outname, "-")) {
+	if (streq(outform, "fs")) {
+		/* Output to directory, outf is not used */
+	} else if (streq(outname, "-")) {
 		outf = stdout;
 	} else {
 		outf = fopen(outname, "wb");
@@ -375,6 +378,8 @@ int main(int argc, char *argv[])
 		dt_to_blob(outf, dti, outversion);
 	} else if (streq(outform, "asm")) {
 		dt_to_asm(outf, dti, outversion);
+	} else if (streq(outform, "fs")) {
+		dt_to_fs(outname, dti);
 	} else if (streq(outform, "null")) {
 		/* do nothing */
 	} else {

--- a/dtc.h
+++ b/dtc.h
@@ -373,5 +373,6 @@ void dt_to_yaml(FILE *f, struct dt_info *dti);
 /* FS trees */
 
 struct dt_info *dt_from_fs(const char *dirname);
+void dt_to_fs(const char *dirname, struct dt_info *dti);
 
 #endif /* DTC_H */

--- a/fstree.c
+++ b/fstree.c
@@ -7,6 +7,17 @@
 
 #include <dirent.h>
 #include <sys/stat.h>
+#include <fcntl.h>
+
+static bool is_reserved_name(const char *name)
+{
+	return streq(name, ".") || streq(name, "..");
+}
+
+static bool is_safe_name(const char *name)
+{
+	return !is_reserved_name(name) && !strchr(name, '/');
+}
 
 static struct node *read_fstree(const char *dirname)
 {
@@ -24,8 +35,7 @@ static struct node *read_fstree(const char *dirname)
 	while ((de = readdir(d)) != NULL) {
 		char *tmpname;
 
-		if (streq(de->d_name, ".")
-		    || streq(de->d_name, ".."))
+		if (is_reserved_name(de->d_name))
 			continue;
 
 		tmpname = join_path(dirname, de->d_name);
@@ -65,6 +75,54 @@ static struct node *read_fstree(const char *dirname)
 	return tree;
 }
 
+
+
+static void write_fstree(const char *dirname, struct node *tree)
+{
+	struct property *prop;
+	struct node *child;
+	char *tmpname;
+	FILE *pfile;
+
+	if (mkdir(dirname, 0777) < 0)
+		die("Cannot create directory \"%s\": %s\n",
+		    dirname, strerror(errno));
+
+	for_each_property(tree, prop) {
+		if (!is_safe_name(prop->name)) {
+			fprintf(stderr,
+				"Warning: Ignoring unsafe property \"%s\"\n",
+				prop->name);
+			continue;
+		}
+
+		tmpname = join_path(dirname, prop->name);
+		pfile = fopen(tmpname, "wb");
+
+		if (!pfile)
+			die("Cannot open \"%s\" for write: %s\n", tmpname,
+			    strerror(errno));
+
+		if (fwrite(prop->val.val, prop->val.len, 1, pfile) != 1)
+			die("Couldn't write to \"%s\": %s\n",
+			    tmpname, strerror(errno));
+		fclose(pfile);
+		free(tmpname);
+	}
+	for_each_child(tree, child) {
+		if (!is_safe_name(child->name)) {
+			fprintf(stderr,
+				"Warning: Ignoring unsafe node \"%s\"\n",
+				child->name);
+			continue;
+		}
+
+		tmpname = join_path(dirname, child->name);
+		write_fstree(tmpname, child);
+		free(tmpname);
+	}
+}
+
 struct dt_info *dt_from_fs(const char *dirname)
 {
 	struct node *tree;
@@ -73,4 +131,9 @@ struct dt_info *dt_from_fs(const char *dirname)
 	tree = name_node(tree, "");
 
 	return build_dt_info(DTSF_V1, NULL, tree, guess_boot_cpuid(tree));
+}
+
+void dt_to_fs(const char *dirname, struct dt_info *dti)
+{
+	write_fstree(dirname, dti->dt);
 }


### PR DESCRIPTION
dtc now supports `-O <fs>`, complementing the `-I <fs>`. The /proc/device-tree style output can be useful for manipulating the dt using simple shell scripts.